### PR TITLE
Fix saving QL chart when queries are empty

### DIFF
--- a/src/ui/units/ql/containers/PaneVisualization/PaneVisualization.tsx
+++ b/src/ui/units/ql/containers/PaneVisualization/PaneVisualization.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import {connect} from 'react-redux';
 import {withRouter} from 'react-router-dom';
 import {compose} from 'recompose';
-import {QLChartType} from 'shared';
 import {DatalensGlobalState} from 'ui';
 import {drawPreview} from 'units/ql/store/actions/ql';
 import SectionVisualization from 'units/wizard/containers/Wizard/SectionVisualization/SectionVisualization';
 
-import {getChartType, getQueries, getQueryValue} from '../../store/reducers/ql';
+import {getIsQLQueryEmpty} from '../../store/reducers/ql';
 import {getAvailableQlVisualizations} from '../../utils/visualization';
 
 import './PaneVisualization.scss';
@@ -36,28 +35,9 @@ class PaneVisualization extends React.PureComponent<
             <SectionVisualization
                 availableVisualizations={getAvailableQlVisualizations()}
                 onUpdate={() => {
-                    let canRerender;
-                    switch (this.props.chartType) {
-                        case QLChartType.Monitoringql:
-                        case QLChartType.Promql: {
-                            const queriesExists = this.props.queries.length !== 0;
-                            const someQueryHasValue = this.props.queries.some((q) =>
-                                this.isQueryNotEmpty(q.value),
-                            );
-                            canRerender = queriesExists && someQueryHasValue;
-                            break;
-                        }
-
-                        case QLChartType.Sql:
-                        default: {
-                            canRerender = this.isQueryNotEmpty(this.props.queryValue);
-                        }
-                    }
-
-                    if (!canRerender) {
+                    if (this.props.isQueryEmpty) {
                         return;
                     }
-
                     this.props.drawPreview({
                         withoutTable: true,
                     });
@@ -65,10 +45,6 @@ class PaneVisualization extends React.PureComponent<
                 qlMode={true}
             />
         );
-    }
-
-    private isQueryNotEmpty(query: string): boolean {
-        return query.trim().length > 0;
     }
 }
 
@@ -78,9 +54,7 @@ const mapDispatchToProps = {
 
 const makeMapStateToProps = (state: DatalensGlobalState) => {
     return {
-        queryValue: getQueryValue(state),
-        queries: getQueries(state),
-        chartType: getChartType(state),
+        isQueryEmpty: getIsQLQueryEmpty(state),
     };
 };
 

--- a/src/ui/units/ql/store/reducers/ql.ts
+++ b/src/ui/units/ql/store/reducers/ql.ts
@@ -15,6 +15,7 @@ import {
 import {selectExtraSettings as getExtraSettingsWizard} from 'units/wizard/selectors/widget';
 
 import {AppStatus, DEFAULT_SALT, PANE_VIEWS, VisualizationStatus} from '../../constants';
+import {isPromQlQueriesEmpty, isQLQueryEmpty} from '../../utils/query';
 import {
     ADD_PARAM,
     ADD_PARAM_IN_QUERY,
@@ -362,10 +363,25 @@ export const getEntryNotChanged = createSelector(
     },
 );
 
+export const getIsQLQueryEmpty = createSelector(
+    [getQueryValue, getQueries, getChartType],
+    (queryValue, queries, chartType): boolean => {
+        switch (chartType) {
+            case QLChartType.Promql:
+            case QLChartType.Monitoringql: {
+                return isPromQlQueriesEmpty(queries);
+            }
+            case QLChartType.Sql:
+            default:
+                return isQLQueryEmpty(queryValue);
+        }
+    },
+);
+
 export const getEntryCanBeSaved = createSelector(
-    [getValid, getEntryIsLocked, getEntryNotChanged, getQueryValue],
-    (valid, entryIsLocked, entryNotChanged, queryValue): boolean => {
-        return valid && Boolean(queryValue) && !entryIsLocked && !entryNotChanged;
+    [getValid, getEntryIsLocked, getEntryNotChanged, getIsQLQueryEmpty],
+    (valid, entryIsLocked, entryNotChanged, isQueryEmpty): boolean => {
+        return valid && !isQueryEmpty && !entryIsLocked && !entryNotChanged;
     },
 );
 

--- a/src/ui/units/ql/utils/query.ts
+++ b/src/ui/units/ql/utils/query.ts
@@ -1,0 +1,15 @@
+import type {QLQuery} from 'shared/types/ql/common';
+
+export const isQLQueryEmpty = (query: string): boolean => {
+    return query.trim().length === 0;
+};
+
+export const isPromQlQueriesEmpty = (queries: QLQuery[]): boolean => {
+    const isQueriesEmpty = queries.length === 0;
+
+    if (isQueriesEmpty) {
+        return true;
+    }
+
+    return queries.every((q) => isQLQueryEmpty(q.value));
+};


### PR DESCRIPTION
The state of the save button was only determined by the `queryValue` parameter, but monitoring and promql don't have this value. They use the `queries` parameter, so it needs to check `queries` for these types of charts