### PR TITLE
Fix alias icon align

### DIFF
--- a/src/ui/units/dash/containers/Dialogs/DialogRelations/components/Content/Content.scss
+++ b/src/ui/units/dash/containers/Dialogs/DialogRelations/components/Content/Content.scss
@@ -56,10 +56,10 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        max-width: 324px;
+        width: 343px;
 
         &_with-icon {
-            max-width: 296px;
+            width: 315px;
         }
     }
 


### PR DESCRIPTION
Before
<img width="565" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/cc4a45be-fad0-4c3d-a36d-e906fb4dd650">

After
<img width="558" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/c8046fdc-281d-4339-8a2c-0862b9946bed">

