### PR TITLE
Fix AsideNavigation react warning on renderContent

### DIFF
--- a/src/ui/datalens/index.tsx
+++ b/src/ui/datalens/index.tsx
@@ -90,7 +90,7 @@ const DatalensPage: React.FC = () => {
     const showAsideHeaderAdapter = getIsAsideHeaderEnabled() && !isEmbeddedMode() && !isTvMode();
 
     if (showAsideHeaderAdapter) {
-        return <AsideHeaderAdapter renderContent={DatalensPageView} />;
+        return <AsideHeaderAdapter renderContent={() => <DatalensPageView />} />;
     }
 
     return <DatalensPageView />;


### PR DESCRIPTION
`renderContent` should be render props