### PR TITLE
Fix export error message

### DIFF
--- a/src/ui/libs/DatalensChartkit/components/ChartKitBase/components/Header/components/Menu/Items/Export/utils.tsx
+++ b/src/ui/libs/DatalensChartkit/components/ChartKitBase/components/Header/components/Menu/Items/Export/utils.tsx
@@ -86,7 +86,9 @@ export const getFileName = (key: string) => {
 };
 
 export const setErrorToast = async (exportResult: ExportResultType) => {
-    let errorStatusText = `(${exportResult?.error?.response?.statusText})`;
+    let errorStatusText = `(${
+        exportResult?.error?.response?.statusText || exportResult?.error?.message
+    })`;
     const errorStatus = exportResult?.error?.response?.status;
     if (errorStatus === 413 && exportResult?.error?.response) {
         try {


### PR DESCRIPTION
Sometimes `exportResult.error.response` is empty 
[Axios Error Handling](https://axios-http.com/docs/handling_errors)