### PR TITLE
Support param `_no_scroll` for embedded dash and preview

### DIFF
--- a/src/ui/constants/common.ts
+++ b/src/ui/constants/common.ts
@@ -256,6 +256,7 @@ export const URL_OPTIONS = {
     NO_CONTROLS: '_no_controls',
     LANGUAGE: '_lang',
     ACTION_PARAMS_ENABLED: '_action_params',
+    NO_SCROLL: '_no_scroll',
 };
 
 export const DLS_SUBJECT = {

--- a/src/ui/styles/dash.scss
+++ b/src/ui/styles/dash.scss
@@ -2,6 +2,10 @@
 
 body.g-root.dl-dash {
     background-color: var(--g-color-base-generic-ultralight);
+
+    &_no-scroll {
+        overflow-y: hidden;
+    }
 }
 
 // to prevent YCSelect elements overflows boundaries on mobile

--- a/src/ui/styles/preview.scss
+++ b/src/ui/styles/preview.scss
@@ -1,0 +1,5 @@
+body.g-root.dl-preview {
+    &_no-scroll {
+        overflow-y: hidden;
+    }
+}

--- a/src/ui/units/dash/containers/App/App.scss
+++ b/src/ui/units/dash/containers/App/App.scss
@@ -7,6 +7,10 @@
     min-width: 1100px;
     flex-direction: column;
 
+    &_embedded {
+        min-height: unset;
+    }
+
     &#{&}_mobile {
         min-width: 320px;
 

--- a/src/ui/units/dash/containers/App/App.tsx
+++ b/src/ui/units/dash/containers/App/App.tsx
@@ -31,6 +31,7 @@ import {DashWrapper} from '../Dash/Dash';
 import './App.scss';
 
 const b = block('app');
+const dashBlock = block('dl-dash');
 
 export function App({...routeProps}: RouteComponentProps) {
     const asideHeaderData = useSelector(selectAsideHeaderData);
@@ -54,14 +55,12 @@ export function App({...routeProps}: RouteComponentProps) {
     const showAsideHeader = !isEmbedded && !isFullscreenMode && isAsideHeaderEnabled;
 
     React.useEffect(() => {
-        Utils.addBodyClass('dl-dash');
+        const dashClasses = dashBlock({'no-scroll': isNoScrollMode()}).split(' ');
 
-        if (isNoScrollMode()) {
-            Utils.addBodyClass('dl-dash_no-scroll');
-        }
+        Utils.addBodyClass(...dashClasses);
 
         return () => {
-            Utils.removeBodyClass('dl-dash', 'dl-dash_no-scroll');
+            Utils.removeBodyClass(...dashClasses);
 
             if (showAsideHeader) {
                 dispatch(setCurrentPageEntry(null));

--- a/src/ui/units/dash/containers/App/App.tsx
+++ b/src/ui/units/dash/containers/App/App.tsx
@@ -89,7 +89,6 @@ export function App({...routeProps}: RouteComponentProps) {
                 return;
             }
 
-            sendEmbedDashHeight(wrapRef);
             dispatch(setTabHashState({tabId: newTabId, stateHashId: newStateHashId, entryId}));
         },
         [entryId, tabs, stateHashId, dispatch],

--- a/src/ui/units/dash/containers/App/App.tsx
+++ b/src/ui/units/dash/containers/App/App.tsx
@@ -16,7 +16,7 @@ import {MobileHeader} from 'ui/components/MobileHeader/MobileHeader';
 import {getIsAsideHeaderEnabled} from '../../../../components/AsideHeaderAdapter';
 import {CurrentPageEntry} from '../../../../components/Navigation/types';
 import {DL, EMBEDDED_DASH_MESSAGE_NAME} from '../../../../constants/common';
-import {isEmbeddedMode, isIframe} from '../../../../utils/embedded';
+import {isEmbeddedMode, isIframe, isNoScrollMode} from '../../../../utils/embedded';
 import {dispatchResize, sendEmbedDashHeight} from '../../modules/helpers';
 import PostMessage, {PostMessageCode} from '../../modules/postMessage';
 import {setTabHashState} from '../../store/actions/dashTyped';
@@ -56,8 +56,12 @@ export function App({...routeProps}: RouteComponentProps) {
     React.useEffect(() => {
         Utils.addBodyClass('dl-dash');
 
+        if (isNoScrollMode()) {
+            Utils.addBodyClass('dl-dash_no-scroll');
+        }
+
         return () => {
-            Utils.removeBodyClass('dl-dash');
+            Utils.removeBodyClass('dl-dash', 'dl-dash_no-scroll');
 
             if (showAsideHeader) {
                 dispatch(setCurrentPageEntry(null));
@@ -85,6 +89,7 @@ export function App({...routeProps}: RouteComponentProps) {
                 return;
             }
 
+            sendEmbedDashHeight(wrapRef);
             dispatch(setTabHashState({tabId: newTabId, stateHashId: newStateHashId, entryId}));
         },
         [entryId, tabs, stateHashId, dispatch],
@@ -136,7 +141,7 @@ export function App({...routeProps}: RouteComponentProps) {
     const showHeader = !isFullscreenMode && !isAsideHeaderEnabled && !isEmbedded && isMobileEnabled;
 
     return (
-        <div className={b({mobile: DL.IS_MOBILE})} ref={wrapRef}>
+        <div className={b({mobile: DL.IS_MOBILE, embedded: isEmbedded})} ref={wrapRef}>
             <LocationChange onLocationChanged={locationChangeHandler} />
             {showHeader && <MobileHeader />}
             <div className={b('content')}>

--- a/src/ui/units/preview/components/App/App.tsx
+++ b/src/ui/units/preview/components/App/App.tsx
@@ -19,6 +19,7 @@ import './App.scss';
 import 'ui/styles/preview.scss';
 
 const b = block('app');
+const previewBlock = block('dl-preview');
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;
@@ -29,12 +30,14 @@ const App: React.FunctionComponent<Props> = (props) => {
     const isAsideHeaderEnabled = getIsAsideHeaderEnabled();
 
     React.useEffect(() => {
+        const previewClasses = previewBlock({'no-scroll': true}).split(' ');
+
         if (isNoScrollMode()) {
-            Utils.addBodyClass('dl-preview', 'dl-preview_no-scroll');
+            Utils.addBodyClass(...previewClasses);
         }
 
         return () => {
-            Utils.removeBodyClass('dl-preview', 'dl-preview_no-scroll');
+            Utils.removeBodyClass(...previewClasses);
         };
     }, []);
 

--- a/src/ui/units/preview/components/App/App.tsx
+++ b/src/ui/units/preview/components/App/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import block from 'bem-cn-lite';
 import once from 'lodash/once';
 import {connect} from 'react-redux';
 import {Route, RouteComponentProps, Switch, withRouter} from 'react-router-dom';
@@ -7,13 +8,17 @@ import {Dispatch, bindActionCreators} from 'redux';
 import {setCurrentPageEntry} from 'store/actions/asideHeader';
 import {DatalensGlobalState} from 'ui';
 import {MobileHeader} from 'ui/components/MobileHeader/MobileHeader';
+import Utils from 'ui/utils/utils';
 
 import {getIsAsideHeaderEnabled} from '../../../../components/AsideHeaderAdapter';
-import {isEmbeddedMode, isIframe} from '../../../../utils/embedded';
+import {isEmbeddedMode, isNoScrollMode} from '../../../../utils/embedded';
 import IndexPage from '../IndexPage/IndexPage';
 import Preview from '../Preview/Preview';
 
 import './App.scss';
+import 'ui/styles/preview.scss';
+
+const b = block('app');
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;
@@ -23,18 +28,26 @@ interface Props extends RouteComponentProps, StateProps, DispatchProps {}
 const App: React.FunctionComponent<Props> = (props) => {
     const isAsideHeaderEnabled = getIsAsideHeaderEnabled();
 
-    const embedded = isIframe() || isEmbeddedMode();
+    React.useEffect(() => {
+        if (isNoScrollMode()) {
+            Utils.addBodyClass('dl-preview', 'dl-preview_no-scroll');
+        }
+
+        return () => {
+            Utils.removeBodyClass('dl-preview', 'dl-preview_no-scroll');
+        };
+    }, []);
 
     return (
-        <div className="app">
-            {embedded || isAsideHeaderEnabled ? null : <MobileHeader />}
+        <div className={b()}>
+            {isEmbeddedMode() || isAsideHeaderEnabled ? null : <MobileHeader />}
             <Switch>
                 <Route
                     path={`/preview/:idOrSource+`}
                     render={(routeProps) => (
                         <Preview
                             {...routeProps}
-                            isEmbedded={Boolean(embedded)}
+                            isEmbedded={isEmbeddedMode()}
                             asideHeaderSize={props.asideHeaderData.size}
                             setPageEntry={once(props.setCurrentPageEntry)}
                         />

--- a/src/ui/utils/embedded.ts
+++ b/src/ui/utils/embedded.ts
@@ -1,4 +1,4 @@
-import {EMBEDDED_MODE} from '../constants';
+import {EMBEDDED_MODE, URL_OPTIONS} from '../constants';
 
 export const isIframe = () => {
     try {
@@ -10,7 +10,7 @@ export const isIframe = () => {
 
 export const isEmbeddedMode = () => {
     const urlParams = new URLSearchParams(window.location.search);
-    const isEmbeddedPreview = urlParams.get('_embedded') === '1';
+    const isEmbeddedPreview = urlParams.get(URL_OPTIONS.EMBEDDED) === '1';
     const isEmbedded = urlParams.get('mode') === EMBEDDED_MODE.EMBEDDED;
     return isIframe() || isEmbedded || isEmbeddedPreview;
 };
@@ -19,4 +19,10 @@ export const isTvMode = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const isTv = urlParams.get('mode') === EMBEDDED_MODE.TV;
     return isTv;
+};
+
+export const isNoScrollMode = () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const isNoScrollEnabled = urlParams.get(URL_OPTIONS.NO_SCROLL) === '1';
+    return isNoScrollEnabled && isEmbeddedMode();
 };

--- a/src/ui/utils/utils.ts
+++ b/src/ui/utils/utils.ts
@@ -173,8 +173,8 @@ export default class Utils {
         window.document.body.classList.add(...className);
     }
 
-    static removeBodyClass(className: string) {
-        window.document.body.classList.remove(className);
+    static removeBodyClass(...className: string[]) {
+        window.document.body.classList.remove(...className);
     }
 
     static setSdk() {


### PR DESCRIPTION
- Support `_no_scroll` param
- Fix too long tabs when switching from a tab with a lot of content in the embedded dash