### PR TITLE
Optimise api get entries datasets fields

### DIFF
--- a/src/shared/schema/mix/actions/dash.ts
+++ b/src/shared/schema/mix/actions/dash.ts
@@ -1,13 +1,81 @@
+import {ContextApiWithRoot} from '@gravity-ui/gateway/build/models/common';
+import {AppContext} from '@gravity-ui/nodekit';
 import {DeepNonNullable} from 'utility-types';
 
+import {Dataset} from '../../../types';
 import {createAction} from '../../gateway-utils';
-import {getTypedApi} from '../../simple-schema';
+import {getTypedApi, simpleSchema} from '../../simple-schema';
 import {
     CollectDashStatsArgs,
     CollectDashStatsResponse,
     GetEntriesDatasetsFieldsArgs,
     GetEntriesDatasetsFieldsResponse,
 } from '../types';
+
+type DatasetDictResponse = {datasetId: string; data: Dataset | null};
+
+const fetchAllDatasets = async ({
+    datasetId,
+    typedApi,
+    ctx,
+}: {
+    datasetId: string;
+    typedApi: ContextApiWithRoot<{root: typeof simpleSchema}>;
+    ctx: AppContext;
+}): Promise<DatasetDictResponse> => {
+    try {
+        const data: Dataset = await typedApi.bi.getDatasetByVersion({
+            datasetId,
+            version: 'draft',
+        });
+        return {
+            datasetId,
+            data,
+        };
+    } catch (error) {
+        ctx.logError('DASH_GET_DATASETS_BY_IDS_FIELDS_GET_DATASET_BY_VERSION_FAILED', error);
+    }
+    return {datasetId, data: null};
+};
+
+const prepareDatasetData = (args: {
+    items: DatasetDictResponse;
+    type: string | null;
+    entryId: string;
+    datasetId: string;
+}) => {
+    const {entryId, datasetId, type, items} = args;
+
+    if (!items.data) {
+        return {entryId, type: null};
+    }
+
+    const {
+        key,
+        dataset: {result_schema},
+    } = items.data;
+
+    // we form an array of elements of the following type:
+    // * wizard and dataset are not in datasetsIds
+    //   {entryId: "0tk6pkyusg", type: "graph_wizard_node", datasetId: "3a3em9nwkk", datasetFields: Array(8)}
+    // * wizard and dataset are in datasetsIds
+    //   {entryId: "0lwgk7z2kw", type: "graph_wizard_node", datasetId: "fbnaupoasc"}
+    // * wizard that doesn't have a datasetId in meta
+    //   {entryId: "0epkfeanqv", type: "graph_wizard_node"}
+    // * node script
+    //   {entryId: "ilslg0le88", type: "graph_node"}
+    return {
+        entryId,
+        type,
+        datasetId,
+        datasetName: key.match(/[^/]*$/)?.[0] || '',
+        datasetFields: result_schema.map(({title, guid, type: fieldType}) => ({
+            title,
+            guid,
+            type: fieldType,
+        })),
+    };
+};
 
 export const dashActions = {
     collectDashStats: createAction<CollectDashStatsResponse, CollectDashStatsArgs>(
@@ -32,85 +100,61 @@ export const dashActions = {
             ids: entriesIds,
             includeLinks: true,
         });
-        // we form an array of elements of the following type:
-        // * wizard and dataset are not in datasetsIds
-        //   {entryId: "0tk6pkyusg", type: "graph_wizard_node", datasetId: "3a3em9nwkk", datasetFields: Array(8)}
-        // * wizard and dataset are in datasetsIds
-        //   {entryId: "0lwgk7z2kw", type: "graph_wizard_node", datasetId: "fbnaupoasc"}
-        // * wizard that doesn't have a datasetId in meta
-        //   {entryId: "0epkfeanqv", type: "graph_wizard_node"}
-        // * node script
-        //   {entryId: "ilslg0le88", type: "graph_node"}
-        const fetchEntries = entries.map(async (entry) => {
-            const {entryId, type, meta, links} = entry;
+
+        const allDatasetsIdsSet = new Set([...datasetsIds]);
+        entries.forEach((entry) => {
+            const {links, meta} = entry;
             const {dataset} = links || {};
             // deprecated
             const {datasetId: metaDatasetId} = meta || {};
             const datasetId = (dataset || metaDatasetId) as string | undefined;
-            const widgetType = type.match(/^[^_]*/)?.[0] || null;
-            // datasetsIds is now ignored because you need to find out the name for all datasets
-            // if (datasetsIds.includes(datasetId)) {
-            //     return {entryId, type: widgetType, datasetId};
-            // }
             if (datasetId) {
-                try {
-                    const {
-                        key,
-                        dataset: {result_schema},
-                    } = await typedApi.bi.getDatasetByVersion({
-                        datasetId,
-                        version: 'draft',
-                    });
+                allDatasetsIdsSet.add(datasetId);
+            }
+        });
 
-                    return {
-                        entryId,
+        const allDatasetsIds = [...allDatasetsIdsSet];
+        const allDatasetsPromises = allDatasetsIds.map((datasetId) =>
+            fetchAllDatasets({datasetId, typedApi, ctx}),
+        );
+
+        const allDatasetsFetchedData = await Promise.all([...allDatasetsPromises]);
+        const allDatasetsFetchedDataDict = allDatasetsFetchedData
+            .filter((item) => Boolean(item.data && item.datasetId))
+            .reduce((res: Record<string, DatasetDictResponse>, item: DatasetDictResponse) => {
+                res[item.datasetId] = {...item};
+                return res;
+            }, {});
+
+        const res: GetEntriesDatasetsFieldsResponse = [];
+        entries.forEach((entry) => {
+            const {links, meta, type, entryId} = entry;
+            const {dataset} = links || {};
+            // deprecated
+            const {datasetId: metaDatasetId} = meta || {};
+            const datasetId = (dataset || metaDatasetId) as string | undefined;
+            if (datasetId) {
+                const widgetType = type.match(/^[^_]*/)?.[0] || null;
+                res.push(
+                    prepareDatasetData({
+                        items: allDatasetsFetchedDataDict[datasetId],
                         type: widgetType,
                         datasetId,
-                        datasetName: key.match(/[^/]*$/)?.[0] || '',
-                        datasetFields: result_schema.map(({title, guid, type: fieldType}) => ({
-                            title,
-                            guid,
-                            type: fieldType,
-                        })),
-                    };
-                } catch (error) {
-                    ctx.logError(
-                        'DASH_GET_ENTRIES_DATASETS_FIELDS_GET_DATASET_BY_VERSION_FAILED',
-                        error,
-                    );
-                }
-            }
-            return {entryId, type: widgetType};
-        });
-        const fetchDatasets = datasetsIds.map(async (datasetId) => {
-            try {
-                const {
-                    key,
-                    dataset: {result_schema},
-                } = await typedApi.bi.getDatasetByVersion({
-                    datasetId,
-                    version: 'draft',
-                });
-
-                return {
-                    entryId: datasetId,
-                    type: 'dataset',
-                    datasetId,
-                    datasetName: key.match(/[^/]*$/)?.[0] || '',
-                    datasetFields: result_schema.map(({title, guid, type: fieldType}) => ({
-                        title,
-                        guid,
-                        type: fieldType,
-                    })),
-                };
-            } catch (error) {
-                ctx.logError(
-                    'DASH_GET_DATASETS_BY_IDS_FIELDS_GET_DATASET_BY_VERSION_FAILED',
-                    error,
+                        entryId,
+                    }),
                 );
             }
-            return {entryId: datasetId, type: null};
         });
-        return await Promise.all([...fetchEntries, ...fetchDatasets]);
+        datasetsIds.forEach((datasetId) => {
+            res.push(
+                prepareDatasetData({
+                    items: allDatasetsFetchedDataDict[datasetId],
+                    type: 'dataset',
+                    entryId: datasetId,
+                    datasetId,
+                }),
+            );
+        });
+        return res;
     }),
 };

--- a/src/shared/schema/mix/types/dash.ts
+++ b/src/shared/schema/mix/types/dash.ts
@@ -19,7 +19,7 @@ export type GetEntriesDatasetsFieldsItem = {
     type: GetEntriesEntryResponse['type'] | null;
     datasetId?: string;
     datasetName?: string;
-    datasetFields?: GetEntriesDatasetsFieldsListItem[];
+    datasetFields?: GetEntriesDatasetsFieldsListItem[] | string[];
 };
 
 export type GetEntriesDatasetsFieldsResponse = GetEntriesDatasetsFieldsItem[];
@@ -27,4 +27,5 @@ export type GetEntriesDatasetsFieldsResponse = GetEntriesDatasetsFieldsItem[];
 export type GetEntriesDatasetsFieldsArgs = {
     entriesIds: string[];
     datasetsIds: string[];
+    format?: 'light' | 'full';
 };

--- a/src/ui/units/dash/containers/Dialogs/DialogRelations/hooks/helpers.ts
+++ b/src/ui/units/dash/containers/Dialogs/DialogRelations/hooks/helpers.ts
@@ -7,7 +7,7 @@ import {
     DashTabItemType,
     DashTabItemWidgetTab,
 } from 'shared';
-import {GetEntriesDatasetsFieldsResponse} from 'shared/schema';
+import {GetEntriesDatasetsFieldsListItem, GetEntriesDatasetsFieldsResponse} from 'shared/schema';
 import {
     DashkitMetaDataItemBase,
     DatasetsData,
@@ -142,11 +142,13 @@ export const getMetaDataWithDatasetInfo = ({
         if (datasetFields) {
             datasetsList[key] = datasetsList[key] || {};
             datasetsList[key].name = datasetName || '';
-            datasetsList[key].fields = datasetFields.map((fieldItem) => ({
-                title: fieldItem.title,
-                guid: fieldItem.guid,
-                dataType: fieldItem.dataType || fieldItem.type || '',
-            }));
+            datasetsList[key].fields = (datasetFields as GetEntriesDatasetsFieldsListItem[]).map(
+                (fieldItem) => ({
+                    title: fieldItem.title,
+                    guid: fieldItem.guid,
+                    dataType: fieldItem.dataType || fieldItem.type || '',
+                }),
+            );
         }
 
         if (datasetId && datasetsList[datasetId]) {

--- a/src/ui/units/dash/containers/Dialogs/DialogRelations/hooks/useRelations.tsx
+++ b/src/ui/units/dash/containers/Dialogs/DialogRelations/hooks/useRelations.tsx
@@ -4,7 +4,10 @@ import type {DashKit} from '@gravity-ui/dashkit';
 import isEmpty from 'lodash/isEmpty';
 import {DashTabItem} from 'shared';
 
-import {GetEntriesDatasetsFieldsResponse} from '../../../../../../../shared/schema';
+import {
+    GetEntriesDatasetsFieldsListItem,
+    GetEntriesDatasetsFieldsResponse,
+} from '../../../../../../../shared/schema';
 import {getSdk} from '../../../../../../libs/schematic-sdk';
 import {getRowTitle} from '../components/Content/helpers';
 import {DEFAULT_ALIAS_NAMESPACE} from '../constants';
@@ -100,7 +103,8 @@ export const useRelations = ({
                             datasetListItem.name = datasetItem.datasetName;
                         }
                         if (!datasetListItem.fields && datasetItem.datasetFields) {
-                            datasetListItem.fields = datasetItem.datasetFields;
+                            datasetListItem.fields =
+                                datasetItem.datasetFields as GetEntriesDatasetsFieldsListItem[];
                         }
                     }
                 });

--- a/src/ui/units/dash/store/actions/dash.js
+++ b/src/ui/units/dash/store/actions/dash.js
@@ -18,7 +18,7 @@ import {collectDashStats} from '../../modules/pushStats';
 import * as actionTypes from '../constants/dashActionTypes';
 import {getFakeDashEntry} from '../utils';
 
-import {SET_ERROR_MODE, SET_STATE, /*loadDashDatasets, */ toggleTableOfContent} from './dashTyped';
+import {SET_ERROR_MODE, SET_STATE, loadDashDatasets, toggleTableOfContent} from './dashTyped';
 import {
     DOES_NOT_EXIST_ERROR_TEXT,
     NOT_FOUND_ERROR_TEXT,
@@ -459,7 +459,7 @@ export const load = ({location, history, params}) => {
                 await dispatch(setEditMode());
             }
 
-            // dispatch(loadDashDatasets(entry, tabId));
+            dispatch(loadDashDatasets(entry, tabId));
         } catch (error) {
             logger.logError('load dash failed', error);
 

--- a/src/ui/units/dash/store/actions/dashTyped.ts
+++ b/src/ui/units/dash/store/actions/dashTyped.ts
@@ -946,7 +946,7 @@ export function loadDashDatasets(entry: Partial<DashState>, tabId: string) {
         }
 
         const entriesDatasetsFields = await getSdk().mix.getEntriesDatasetsFields(
-            {entriesIds, datasetsIds: []},
+            {entriesIds, datasetsIds: [], format: 'light'},
             {concurrentId: LOAD_DASH_DATASETS_CONCURRENT_ID},
         );
 

--- a/src/ui/units/dash/store/actions/dashTyped.ts
+++ b/src/ui/units/dash/store/actions/dashTyped.ts
@@ -11,7 +11,6 @@ import {
     DATASET_FIELD_TYPES,
     DashTab,
     DashTabItem,
-    DashTabItemControlDataset,
     DashTabItemControlSourceType,
     DashTabItemType,
     Dataset,
@@ -930,35 +929,24 @@ export function loadDashDatasets(entry: Partial<DashState>, tabId: string) {
         if (!dashTabItems.length) {
             return;
         }
-        let datasetsIds: string[] = [];
         let entriesIds: string[] = [];
         dashTabItems.forEach((dashItem) => {
-            if (
-                dashItem.type === DashTabItemType.Control &&
-                dashItem.data.sourceType === DashTabItemControlSourceType.Dataset
-            ) {
-                const dataSource = dashItem.data.source as DashTabItemControlDataset['source'];
-                if (dataSource.datasetId) {
-                    datasetsIds.push(dataSource.datasetId);
-                }
-            } else if (dashItem.type === DashTabItemType.Widget) {
+            if (dashItem.type === DashTabItemType.Widget) {
                 const chartData = dashItem.data;
-                const widgetChartIds = chartData.tabs.map((chartTabItem) => chartTabItem.chartId);
+                const widgetChartIds = chartData.tabs
+                    .filter((chartTabItem) => Boolean(chartTabItem.enableActionParams))
+                    ?.map((chartTabItem) => chartTabItem.chartId);
                 entriesIds = entriesIds.concat(widgetChartIds);
             }
         });
-        datasetsIds = [...new Set(datasetsIds)];
         entriesIds = [...new Set(entriesIds)];
 
-        if (isEmpty(datasetsIds) && isEmpty(entriesIds)) {
+        if (isEmpty(entriesIds)) {
             return;
         }
 
         const entriesDatasetsFields = await getSdk().mix.getEntriesDatasetsFields(
-            {
-                entriesIds,
-                datasetsIds,
-            },
+            {entriesIds, datasetsIds: []},
             {concurrentId: LOAD_DASH_DATASETS_CONCURRENT_ID},
         );
 

--- a/src/ui/units/dash/utils/helpers.ts
+++ b/src/ui/units/dash/utils/helpers.ts
@@ -1,5 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 import {DashTab, DashTabItem, DashTabItemWidget, DashTabItemWidgetTab, StringParams} from 'shared';
+import {GetEntriesDatasetsFieldsListItem} from 'shared/schema';
 
 import {DashState} from '../store/reducers/dashTypedReducer';
 
@@ -25,14 +26,20 @@ export const getConfigWithoutDSDefaults = (args: {
                 const newWidgetTabItem: DashTabItemWidgetTab = {...widgetTabItem, params: {}};
                 const newParams: StringParams = {};
                 if (widgetTabItem.chartId && dashDatasetsFields?.length) {
-                    const datasetFields =
+                    const datasetFields: GetEntriesDatasetsFieldsListItem[] | string[] =
                         dashDatasetsFields.find(
                             (widgetWithDS) => widgetWithDS.entryId === widgetTabItem.chartId,
                         )?.datasetFields || [];
 
-                    const datasetsGuids = datasetFields.map(
-                        (datasetFieldItem) => datasetFieldItem.guid,
-                    );
+                    let datasetsGuids: string[] = [];
+                    if (datasetFields.length && typeof datasetFields[0] === 'string') {
+                        datasetsGuids = datasetFields as string[];
+                    } else {
+                        datasetsGuids = datasetFields.map(
+                            (datasetFieldItem) =>
+                                (datasetFieldItem as GetEntriesDatasetsFieldsListItem).guid,
+                        );
+                    }
 
                     for (const [key, val] of Object.entries(widgetTabItem.params)) {
                         if (!datasetsGuids.includes(key)) {
@@ -87,7 +94,11 @@ export const getConfigWithDSDefaults = (
                 if (widgetItem.enableActionParams && chartDataset && isEmpty(widgetItem.params)) {
                     const params: StringParams = {};
                     chartDataset.datasetFields?.forEach((item) => {
-                        params[item.guid] = '';
+                        const guid =
+                            typeof item === 'string'
+                                ? item
+                                : (item as GetEntriesDatasetsFieldsListItem).guid;
+                        params[guid] = '';
                     });
 
                     newTab = {...widgetItem, params};


### PR DESCRIPTION
- Sending only widgets ids with enabled actionParams
- Optimised fetch datasets fields api (for both usages: in relations & in loading dash datasets info)
- Add light format for api & support it in helpers (there is no need full info of datasets schemas, only guids)
- Enable dash datasets loading