### PR TITLE
Add query name value editing for QL chart

### DIFF
--- a/src/server/components/charts-engine/components/chart-generator.ts
+++ b/src/server/components/charts-engine/components/chart-generator.ts
@@ -138,8 +138,8 @@ export type ChartTemplates = {
 type ChartTemplate = {
     module: string;
     identifyParams: (data: unknown, req: Request) => StringParams;
-    identifyChartType: (data: unknown) => string;
-    identifyLinks: (data: unknown) => Record<string, string>;
+    identifyChartType: (data: unknown, req: Request) => string;
+    identifyLinks: (data: unknown, req: Request) => Record<string, string>;
 };
 
 type Chart = {
@@ -191,11 +191,11 @@ export const chartGenerator = {
 
         const params = chartTemplate.identifyParams(data, req);
 
-        const type = chartTemplate.identifyChartType(data);
+        const type = chartTemplate.identifyChartType(data, req);
 
         let links;
         if (chartTemplate.identifyLinks) {
-            links = chartTemplate.identifyLinks(data);
+            links = chartTemplate.identifyLinks(data, req);
         }
 
         chart.params = chart.params.replace('#params', JSON.stringify(params));

--- a/src/server/components/charts-engine/components/processor/sandbox.ts
+++ b/src/server/components/charts-engine/components/processor/sandbox.ts
@@ -4,7 +4,7 @@ import {Keysets, ServerI18n} from '../../../../../i18n/types';
 import {initI18n} from '../../../../../i18n/utils';
 import {ChartsInsight, DashWidgetConfig} from '../../../../../shared';
 import {IChartEditor} from '../../../../../shared/types';
-import {keysetsByLang} from '../../../../utils/language';
+import {getTranslationFn, keysetsByLang} from '../../../../utils/language';
 import {config} from '../../constants';
 import {resolveIntervalDate, resolveOperation, resolveRelativeDate} from '../utils';
 
@@ -127,13 +127,7 @@ const generateInstance = ({
     ChartEditor.getUserLang = () => userLang;
 
     const i18n = getI18n(userLang || DEFAULT_USER_LANG);
-    ChartEditor.getTranslation = (
-        keyset: string,
-        key: string,
-        params?: Record<string, string | number>,
-    ) => {
-        return i18n.keyset(keyset as keyof Keysets)(key, params);
-    };
+    ChartEditor.getTranslation = getTranslationFn(i18n);
 
     const instance = {
         module: moduleObject,

--- a/src/server/components/charts-engine/components/processor/sandbox.ts
+++ b/src/server/components/charts-engine/components/processor/sandbox.ts
@@ -3,8 +3,9 @@ import vm from 'vm';
 import {Keysets, ServerI18n} from '../../../../../i18n/types';
 import {initI18n} from '../../../../../i18n/utils';
 import {ChartsInsight, DashWidgetConfig} from '../../../../../shared';
+import {getTranslationFn} from '../../../../../shared/modules/language';
 import {IChartEditor} from '../../../../../shared/types';
-import {getTranslationFn, keysetsByLang} from '../../../../utils/language';
+import {keysetsByLang} from '../../../../utils/language';
 import {config} from '../../constants';
 import {resolveIntervalDate, resolveOperation, resolveRelativeDate} from '../utils';
 
@@ -127,7 +128,7 @@ const generateInstance = ({
     ChartEditor.getUserLang = () => userLang;
 
     const i18n = getI18n(userLang || DEFAULT_USER_LANG);
-    ChartEditor.getTranslation = getTranslationFn(i18n);
+    ChartEditor.getTranslation = getTranslationFn(i18n.getI18nServer());
 
     const instance = {
         module: moduleObject,

--- a/src/server/configs/shared/ql-chart-template.ts
+++ b/src/server/configs/shared/ql-chart-template.ts
@@ -4,14 +4,16 @@ import type {ServerI18n} from '../../../i18n/types';
 import type {QlExtendedConfig, StringParams} from '../../../shared';
 import {QLChartType, QL_TYPE, isMonitoringOrPrometheusChart} from '../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../shared/modules/config/ql';
-import {getTranslationFn} from '../../utils/language';
+import {getTranslationFn} from '../../../shared/modules/language';
 
 export default {
     module: 'libs/qlchart/v1',
     identifyParams: (chart: QlExtendedConfig, req: Request) => {
         const i18nServer: ServerI18n = req.ctx.get('i18n');
 
-        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
+        const config = mapQlConfigToLatestVersion(chart, {
+            i18n: getTranslationFn(i18nServer.getI18nServer()),
+        });
         const {chartType, params} = config;
 
         const availableParams: StringParams = {};
@@ -44,7 +46,9 @@ export default {
     identifyChartType: (chart: QlExtendedConfig, req: Request) => {
         const i18nServer: ServerI18n = req.ctx.get('i18n');
 
-        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
+        const config = mapQlConfigToLatestVersion(chart, {
+            i18n: getTranslationFn(i18nServer.getI18nServer()),
+        });
 
         const {visualization, chartType} = config;
         const id = visualization.id;
@@ -78,7 +82,9 @@ export default {
     identifyLinks: (chart: QlExtendedConfig, req: Request) => {
         const i18nServer: ServerI18n = req.ctx.get('i18n');
 
-        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
+        const config = mapQlConfigToLatestVersion(chart, {
+            i18n: getTranslationFn(i18nServer.getI18nServer()),
+        });
         return {
             connection: config.connection.entryId,
         };

--- a/src/server/configs/shared/ql-chart-template.ts
+++ b/src/server/configs/shared/ql-chart-template.ts
@@ -1,11 +1,17 @@
+import type {Request} from '@gravity-ui/expresskit';
+
+import type {ServerI18n} from '../../../i18n/types';
 import type {QlExtendedConfig, StringParams} from '../../../shared';
 import {QLChartType, QL_TYPE, isMonitoringOrPrometheusChart} from '../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../shared/modules/config/ql';
+import {getTranslationFn} from '../../utils/language';
 
 export default {
     module: 'libs/qlchart/v1',
-    identifyParams: (chart: QlExtendedConfig) => {
-        const config = mapQlConfigToLatestVersion(chart);
+    identifyParams: (chart: QlExtendedConfig, req: Request) => {
+        const i18nServer: ServerI18n = req.ctx.get('i18n');
+
+        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
         const {chartType, params} = config;
 
         const availableParams: StringParams = {};
@@ -35,8 +41,10 @@ export default {
 
         return availableParams;
     },
-    identifyChartType: (chart: QlExtendedConfig) => {
-        const config = mapQlConfigToLatestVersion(chart);
+    identifyChartType: (chart: QlExtendedConfig, req: Request) => {
+        const i18nServer: ServerI18n = req.ctx.get('i18n');
+
+        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
 
         const {visualization, chartType} = config;
         const id = visualization.id;
@@ -67,8 +75,10 @@ export default {
                 return QL_TYPE.GRAPH_QL_NODE;
         }
     },
-    identifyLinks: (chart: QlExtendedConfig) => {
-        const config = mapQlConfigToLatestVersion(chart);
+    identifyLinks: (chart: QlExtendedConfig, req: Request) => {
+        const i18nServer: ServerI18n = req.ctx.get('i18n');
+
+        const config = mapQlConfigToLatestVersion(chart, {i18n: getTranslationFn(i18nServer)});
         return {
             connection: config.connection.entryId,
         };

--- a/src/server/modes/charts/plugins/ql/config.ts
+++ b/src/server/modes/charts/plugins/ql/config.ts
@@ -1,14 +1,21 @@
 import type {HighchartsWidgetData} from '@gravity-ui/chartkit/highcharts';
 
-import {DEFAULT_CHART_LINES_LIMIT, Feature, isEnabledServerFeature} from '../../../../../shared';
+import {
+    DEFAULT_CHART_LINES_LIMIT,
+    Feature,
+    IChartEditor,
+    isEnabledServerFeature,
+} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 import {registry} from '../../../../registry';
 
 import {log} from './utils/misc-helpers';
 
-export default ({shared}: {shared: QlConfig}) => {
-    const qlConfig = mapQlConfigToLatestVersion(shared);
+export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) => {
+    const qlConfig = mapQlConfigToLatestVersion(shared, {
+        i18n: ChartEditor.getTranslation,
+    });
 
     const config: Pick<
         HighchartsWidgetData['config'],

--- a/src/server/modes/charts/plugins/ql/d3.ts
+++ b/src/server/modes/charts/plugins/ql/d3.ts
@@ -1,7 +1,16 @@
+import type {IChartEditor} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 import {buildD3Config as buildD3CommonConfig} from '../datalens/d3';
 
-export function buildD3Config({shared}: {shared: QlConfig}) {
-    return buildD3CommonConfig(mapQlConfigToLatestVersion(shared));
+export function buildD3Config({
+    shared,
+    ChartEditor,
+}: {
+    shared: QlConfig;
+    ChartEditor: IChartEditor;
+}) {
+    return buildD3CommonConfig(
+        mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation}),
+    );
 }

--- a/src/server/modes/charts/plugins/ql/highcharts.ts
+++ b/src/server/modes/charts/plugins/ql/highcharts.ts
@@ -1,9 +1,10 @@
+import type {IChartEditor} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 
 // eslint-disable-next-line complexity
-export default ({shared}: {shared: QlConfig}) => {
-    const config = mapQlConfigToLatestVersion(shared);
+export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) => {
+    const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const xAxis: Highcharts.Options['xAxis'] = {
         endOnTick: false,

--- a/src/server/modes/charts/plugins/ql/js.ts
+++ b/src/server/modes/charts/plugins/ql/js.ts
@@ -43,7 +43,7 @@ export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEdi
     let prepare;
     let result;
 
-    const config = mapQlConfigToLatestVersion(shared);
+    const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const {columns, rows} = getColumnsAndRows({
         chartType: config.chartType,

--- a/src/server/modes/charts/plugins/ql/library-config.ts
+++ b/src/server/modes/charts/plugins/ql/library-config.ts
@@ -1,4 +1,9 @@
-import {ChartsConfigVersion, ServerVisualization, isYAGRVisualization} from '../../../../../shared';
+import {
+    ChartsConfigVersion,
+    IChartEditor,
+    ServerVisualization,
+    isYAGRVisualization,
+} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 import buildHighchartsConfigWizard from '../datalens/highcharts';
@@ -7,13 +12,13 @@ import buildHighchartsConfig from './highcharts';
 import {log} from './utils/misc-helpers';
 import buildYagrConfig from './yagr';
 
-export default ({shared}: {shared: QlConfig}) => {
-    const config = mapQlConfigToLatestVersion(shared);
+export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) => {
+    const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const visualization = config.visualization as ServerVisualization;
 
     if (isYAGRVisualization(config.chartType, visualization.id)) {
-        const result = buildYagrConfig({shared});
+        const result = buildYagrConfig({shared, ChartEditor});
 
         log('LIBRARY CONFIG (YAGR):');
         log(result);
@@ -39,7 +44,7 @@ export default ({shared}: {shared: QlConfig}) => {
 
         return result;
     } else {
-        const result = buildHighchartsConfig({shared: config});
+        const result = buildHighchartsConfig({shared: config, ChartEditor});
 
         log('LIBRARY CONFIG (HC):');
         log(result);

--- a/src/server/modes/charts/plugins/ql/url.ts
+++ b/src/server/modes/charts/plugins/ql/url.ts
@@ -28,7 +28,7 @@ const resolveUrlParameter = (urlParamValue: string | string[]) => {
 };
 
 export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) => {
-    const config = mapQlConfigToLatestVersion(shared);
+    const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const urlParams = ChartEditor.getParams();
 

--- a/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
+++ b/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
@@ -1,3 +1,4 @@
+import type {QLConfigQuery} from '../../../../../../../shared';
 import {buildSource, iterateThroughVisibleQueries} from '../misc-helpers';
 
 const MOCK_ID = 'MOCK_ID';
@@ -86,12 +87,12 @@ describe('iterateThroughVisibleQueries', () => {
     it('should execute callback only for queries where hidden property is falsy', () => {
         const cb = jest.fn();
 
-        const queries = [
-            {value: 'sql-1', params: [], hidden: false},
-            {value: 'sql-2', params: [], hidden: true},
-            {value: 'sql-3', params: [], hidden: false},
-            {value: 'sql-4', params: [], hidden: false},
-            {value: 'sql-5', params: []},
+        const queries: QLConfigQuery[] = [
+            {queryName: 'Query #1', value: 'sql-1', params: [], hidden: false},
+            {queryName: 'Query #2', value: 'sql-2', params: [], hidden: true},
+            {queryName: 'Query #3', value: 'sql-3', params: [], hidden: false},
+            {queryName: 'Query #4', value: 'sql-4', params: [], hidden: false},
+            {queryName: 'Query #5', value: 'sql-5', params: []},
         ];
 
         iterateThroughVisibleQueries(queries, cb);

--- a/src/server/modes/charts/plugins/ql/utils/misc-helpers.ts
+++ b/src/server/modes/charts/plugins/ql/utils/misc-helpers.ts
@@ -662,7 +662,7 @@ export function getColumnsAndRows({
                 columnsByQuery[i] = localColumns;
             }
         });
-        iterateThroughVisibleQueries(queries, (_query, i) => {
+        iterateThroughVisibleQueries(queries, (query, i) => {
             let localRows;
 
             try {
@@ -678,7 +678,7 @@ export function getColumnsAndRows({
             }
 
             localRows.forEach((row) => {
-                row.push(`Query #${i}`);
+                row.push(query.queryName);
             });
 
             if (rows.length > 0) {

--- a/src/server/modes/charts/plugins/ql/yagr.ts
+++ b/src/server/modes/charts/plugins/ql/yagr.ts
@@ -1,6 +1,6 @@
 import type {ChartType, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 
-import {IChartEditor, ServerVisualization} from '../../../../../shared';
+import {IChartEditor, QlVisualizationId, ServerVisualization} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 
@@ -53,7 +53,7 @@ export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEdi
 
     const visualizationId = config.visualization.highchartsId || config.visualization.id;
 
-    const tracking = visualizationId === 'area' ? 'area' : 'sticky';
+    const tracking = visualizationId === QlVisualizationId.Area ? 'area' : 'sticky';
 
     const title =
         config.extraSettings?.titleMode === 'show' && config.extraSettings.title

--- a/src/server/modes/charts/plugins/ql/yagr.ts
+++ b/src/server/modes/charts/plugins/ql/yagr.ts
@@ -1,6 +1,6 @@
 import type {ChartType, TooltipOptions, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 
-import {ServerVisualization} from '../../../../../shared';
+import {IChartEditor, ServerVisualization} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
 import type {QlConfig} from '../../../../../shared/types/config/ql';
 
@@ -43,8 +43,8 @@ const applyPlaceholderSettingsToYAxis = ({
     return {scale};
 };
 
-export default ({shared}: {shared: QlConfig}) => {
-    const config = mapQlConfigToLatestVersion(shared);
+export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) => {
+    const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const type = (config.visualization.highchartsId || config.visualization.id) as ChartType;
 

--- a/src/server/modes/charts/plugins/ql/yagr.ts
+++ b/src/server/modes/charts/plugins/ql/yagr.ts
@@ -1,4 +1,4 @@
-import type {ChartType, TooltipOptions, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
+import type {ChartType, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 
 import {IChartEditor, ServerVisualization} from '../../../../../shared';
 import {mapQlConfigToLatestVersion} from '../../../../../shared/modules/config/ql';
@@ -51,8 +51,9 @@ export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEdi
     const percent =
         config.visualization.id === 'area100p' || config.visualization.id === 'column100p';
 
-    const tracking = (config.visualization.highchartsId ||
-        config.visualization.id) as TooltipOptions['tracking'];
+    const visualizationId = config.visualization.highchartsId || config.visualization.id;
+
+    const tracking = visualizationId === 'area' ? 'area' : 'sticky';
 
     const title =
         config.extraSettings?.titleMode === 'show' && config.extraSettings.title

--- a/src/server/utils/language.ts
+++ b/src/server/utils/language.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import {I18N_DEST_PATH} from '../../i18n/constants';
 import {readKeysets} from '../../i18n/read-keysets';
-import type {Keysets} from '../../i18n/types';
+import type {Keysets, ServerI18n} from '../../i18n/types';
 import {Language} from '../../shared/constants';
 
 export type KeysetData = {content: Keysets; filename: string};
@@ -73,3 +73,9 @@ export function getLang({
 
     return lang;
 }
+
+export const getTranslationFn =
+    (i18n: ServerI18n) =>
+    (keyset: string, key: string, params?: Record<string, string | number>) => {
+        return i18n.keyset(keyset as keyof Keysets)(key, params);
+    };

--- a/src/server/utils/language.ts
+++ b/src/server/utils/language.ts
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import {I18N_DEST_PATH} from '../../i18n/constants';
 import {readKeysets} from '../../i18n/read-keysets';
-import type {Keysets, ServerI18n} from '../../i18n/types';
+import type {Keysets} from '../../i18n/types';
 import {Language} from '../../shared/constants';
 
 export type KeysetData = {content: Keysets; filename: string};
@@ -73,9 +73,3 @@ export function getLang({
 
     return lang;
 }
-
-export const getTranslationFn =
-    (i18n: ServerI18n) =>
-    (keyset: string, key: string, params?: Record<string, string | number>) => {
-        return i18n.keyset(keyset as keyof Keysets)(key, params);
-    };

--- a/src/shared/modules/config/ql/__tests__/mapQlConfigToLatestVersion.test.ts
+++ b/src/shared/modules/config/ql/__tests__/mapQlConfigToLatestVersion.test.ts
@@ -1,4 +1,4 @@
-import type {QLEntryDataShared} from '../../../../types';
+import type {QlConfig} from '../../../../types';
 import {QlConfigVersions} from '../../../../types/ql/versions';
 import {mapQlConfigToLatestVersion} from '../mapQlConfigToLatestVersion';
 
@@ -8,9 +8,9 @@ describe('mapQlConfigToLatestVersion', () => {
 
         const latest = versions[versions.length - 1];
 
-        const config = {} as QLEntryDataShared;
+        const config = {} as QlConfig;
 
-        const latestConfig = mapQlConfigToLatestVersion(config);
+        const latestConfig = mapQlConfigToLatestVersion(config, {i18n: jest.fn()});
 
         expect(latestConfig.version).toEqual(latest);
     });

--- a/src/shared/modules/config/ql/__tests__/v2.test.ts
+++ b/src/shared/modules/config/ql/__tests__/v2.test.ts
@@ -1,0 +1,66 @@
+import type {QlConfigV1} from '../../../../types/config/ql/v1';
+import {QlConfigVersions} from '../../../../types/ql/versions';
+import {mapV1ConfigToV2} from '../v2/mapV1ConfigToV2';
+
+const mockedI18n = (_keyset: string, _key: string) => 'Query';
+
+describe('mapV1ToV2Config', () => {
+    it('should add queryName to all queries', () => {
+        const config = {
+            queries: [
+                {
+                    params: [],
+                    value: 'test',
+                    hidden: false,
+                },
+                {
+                    params: [
+                        {name: 'test-param', type: 'string', defaultValue: 'test-param-value'},
+                    ],
+                    value: 'test2',
+                    hidden: true,
+                },
+                {
+                    params: [],
+                    value: 'test3',
+                    hidden: true,
+                },
+            ],
+            version: QlConfigVersions.V1,
+        } as unknown as QlConfigV1;
+
+        const result = mapV1ConfigToV2(config, mockedI18n);
+
+        expect(result.queries).toEqual([
+            {
+                params: [],
+                value: 'test',
+                hidden: false,
+                queryName: 'Query 1',
+            },
+            {
+                params: [{name: 'test-param', type: 'string', defaultValue: 'test-param-value'}],
+                value: 'test2',
+                hidden: true,
+                queryName: 'Query 2',
+            },
+            {
+                params: [],
+                value: 'test3',
+                hidden: true,
+                queryName: 'Query 3',
+            },
+        ]);
+    });
+
+    it('should return same config with new version, if queries doesnt exists', () => {
+        const config = {
+            version: QlConfigVersions.V1,
+            visualization: {id: 'line'},
+        } as unknown as QlConfigV1;
+
+        const result = mapV1ConfigToV2(config, mockedI18n);
+
+        expect(result).toMatchObject({...config, version: '2'});
+    });
+});

--- a/src/shared/modules/config/ql/mapQlConfigToLatestVersion.ts
+++ b/src/shared/modules/config/ql/mapQlConfigToLatestVersion.ts
@@ -1,12 +1,26 @@
 import type {QlConfig, QlExtendedConfig} from '../../../types';
+import type {GetTranslationFn} from '../../../types/language';
+import {QlConfigVersions} from '../../../types/ql/versions';
 
 import {mapUndefinedConfigToV1} from './v1/mapUndefinedConfigToV1';
+import {mapV1ConfigToV2} from './v2/mapV1ConfigToV2';
 
-export const mapQlConfigToLatestVersion = (extendedConfig: QlExtendedConfig): QlConfig => {
+type MapQlConfigToLatestVersionOptions = {
+    i18n: GetTranslationFn;
+};
+
+export const mapQlConfigToLatestVersion = (
+    extendedConfig: QlExtendedConfig,
+    {i18n}: MapQlConfigToLatestVersionOptions,
+): QlConfig => {
     let config = extendedConfig;
 
     if (typeof config.version === 'undefined') {
         config = mapUndefinedConfigToV1(config);
+    }
+
+    if (config.version === QlConfigVersions.V1) {
+        config = mapV1ConfigToV2(config, i18n);
     }
 
     return config;

--- a/src/shared/modules/config/ql/v2/mapV1ConfigToV2.ts
+++ b/src/shared/modules/config/ql/v2/mapV1ConfigToV2.ts
@@ -1,0 +1,7 @@
+import type {QlConfigV1} from '../../../../types/config/ql/v1';
+import type {QlConfigV2} from '../../../../types/config/ql/v2';
+import type {GetTranslationFn} from '../../../../types/language';
+
+export const mapV1ConfigToV2 = (config: QlConfigV1, _i18n: GetTranslationFn): QlConfigV2 => {
+    return config as unknown as QlConfigV2;
+};

--- a/src/shared/modules/config/ql/v2/mapV1ConfigToV2.ts
+++ b/src/shared/modules/config/ql/v2/mapV1ConfigToV2.ts
@@ -1,7 +1,26 @@
-import type {QlConfigV1} from '../../../../types/config/ql/v1';
-import type {QlConfigV2} from '../../../../types/config/ql/v2';
+import type {QLQueryV1, QlConfigV1} from '../../../../types/config/ql/v1';
+import type {QLQueryV2, QlConfigV2} from '../../../../types/config/ql/v2';
 import type {GetTranslationFn} from '../../../../types/language';
+import {QlConfigVersions} from '../../../../types/ql/versions';
 
-export const mapV1ConfigToV2 = (config: QlConfigV1, _i18n: GetTranslationFn): QlConfigV2 => {
-    return config as unknown as QlConfigV2;
+export const mapV1ConfigToV2 = (config: QlConfigV1, i18n: GetTranslationFn): QlConfigV2 => {
+    if (!config.queries) {
+        return {
+            ...config,
+            version: QlConfigVersions.V2,
+        } as QlConfigV2;
+    }
+
+    const mapQuery = (query: QLQueryV1, index: number): QLQueryV2 => {
+        return {
+            ...query,
+            queryName: `${i18n('sql', 'label_query')} ${index + 1}`,
+        };
+    };
+
+    return {
+        ...config,
+        version: QlConfigVersions.V2,
+        queries: config.queries.map(mapQuery),
+    };
 };

--- a/src/shared/modules/language.ts
+++ b/src/shared/modules/language.ts
@@ -1,0 +1,7 @@
+import type {Keysets, TypedI18n} from '../../i18n/types';
+
+export const getTranslationFn =
+    (i18n: TypedI18n) =>
+    (keyset: string, key: string, params?: Record<string, string | number>) => {
+        return i18n.keyset(keyset as keyof Keysets)(key, params);
+    };

--- a/src/shared/types/config/ql/index.ts
+++ b/src/shared/types/config/ql/index.ts
@@ -1,43 +1,44 @@
 import type {MonitoringPresetV1, MonitoringPresetV2, QLEntryDataShared} from '../../ql/common';
 
+import {QlConfigV1} from './v1';
 import {
-    QLParamIntervalV1,
-    QLParamV1,
-    QLPreviewTableDataColumnV1,
-    QLPreviewTableDataRowV1,
-    QLPreviewTableDataV1,
-    QLQueryV1,
-    QLRequestParamV1,
-    QLResultEntryMetadataDataColumnOrGroupV1,
-    QLResultEntryMetadataDataColumnV1,
-    QLResultEntryMetadataDataGroupV1,
-    QlConfigV1,
-} from './v1';
+    QLParamIntervalV2,
+    QLParamV2,
+    QLPreviewTableDataColumnV2,
+    QLPreviewTableDataRowV2,
+    QLPreviewTableDataV2,
+    QLQueryV2,
+    QLRequestParamV2,
+    QLResultEntryMetadataDataColumnOrGroupV2,
+    QLResultEntryMetadataDataColumnV2,
+    QLResultEntryMetadataDataGroupV2,
+    QlConfigV2,
+} from './v2';
 
-export type QlConfig = QlConfigV1;
+export type QlConfig = QlConfigV2;
 
-export type QlPreviousConfig = QLEntryDataShared;
+export type QlPreviousConfig = QLEntryDataShared | QlConfigV1;
 
 export type QlExtendedConfig = QlConfig | QlPreviousConfig;
 
-export type QLConfigQuery = QLQueryV1;
+export type QLConfigQuery = QLQueryV2;
 
-export type QlConfigResultEntryMetadataDataGroup = QLResultEntryMetadataDataGroupV1;
+export type QlConfigResultEntryMetadataDataGroup = QLResultEntryMetadataDataGroupV2;
 
-export type QlConfigResultEntryMetadataDataColumn = QLResultEntryMetadataDataColumnV1;
+export type QlConfigResultEntryMetadataDataColumn = QLResultEntryMetadataDataColumnV2;
 
-export type QlConfigParamInterval = QLParamIntervalV1;
+export type QlConfigParamInterval = QLParamIntervalV2;
 
-export type QlConfigParam = QLParamV1;
+export type QlConfigParam = QLParamV2;
 
-export type QlConfigRequestParam = QLRequestParamV1;
+export type QlConfigRequestParam = QLRequestParamV2;
 
-export type QlConfigResultEntryMetadataDataColumnOrGroup = QLResultEntryMetadataDataColumnOrGroupV1;
+export type QlConfigResultEntryMetadataDataColumnOrGroup = QLResultEntryMetadataDataColumnOrGroupV2;
 
-export type QlConfigPreviewTableDataColumn = QLPreviewTableDataColumnV1;
+export type QlConfigPreviewTableDataColumn = QLPreviewTableDataColumnV2;
 
-export type QlConfigPreviewTableDataRow = QLPreviewTableDataRowV1;
+export type QlConfigPreviewTableDataRow = QLPreviewTableDataRowV2;
 
-export type QlConfigPreviewTableData = QLPreviewTableDataV1;
+export type QlConfigPreviewTableData = QLPreviewTableDataV2;
 
 export type MonitoringPreset = MonitoringPresetV1 | MonitoringPresetV2;

--- a/src/shared/types/config/ql/v2.ts
+++ b/src/shared/types/config/ql/v2.ts
@@ -1,0 +1,101 @@
+import {QLChartType} from '../../../constants';
+import {QlConfigVersions} from '../../ql/versions';
+import {CommonSharedExtraSettings, Field, ShapesConfig, Shared} from '../../wizard';
+
+export interface QLResultEntryMetadataDataGroupV2 {
+    group: boolean;
+    undragable: boolean;
+    name: string;
+    capacity?: number;
+    size: number;
+    id?: string;
+    allowedTypes?: string[];
+    pseudo?: boolean;
+}
+
+export interface QLResultEntryMetadataDataColumnV2 {
+    // typeName -- legacy type that is incompatible with Field
+    // How to turn on wizard ql common visualization -- you can delete
+    typeName: string;
+
+    // biType -- a new type compatible with Field and general visualization section
+    biType?: string;
+
+    name: string;
+    id?: string;
+    undragable?: boolean;
+    pseudo?: boolean;
+}
+
+export interface QLParamIntervalV2 {
+    from: string | undefined;
+    to: string | undefined;
+}
+
+export interface QLParamV2 {
+    name: string;
+    type: string;
+    defaultValue: string | string[] | QLParamIntervalV2 | undefined;
+    overridenValue?: string | string[] | QLParamIntervalV2;
+}
+
+// Description of the request parameters.
+export interface QLRequestParamV2 {
+    type_name: string;
+    value: string | string[];
+}
+
+export type QLResultEntryMetadataDataColumnOrGroupV2 =
+    | QLResultEntryMetadataDataGroupV2
+    | QLResultEntryMetadataDataColumnV2;
+
+interface QLEntryDataSharedConnectionV2 {
+    entryId: string;
+    type: string;
+}
+
+export interface QLQueryV2 {
+    value: string;
+    hidden?: boolean;
+    params: QLParamV2[];
+    queryName: string;
+}
+
+export interface QlConfigV2 {
+    version: QlConfigVersions.V2;
+    // The type of template used to generate a chart at the ChartsEngine level, a low-level thing
+    type: string;
+
+    // Chart type should be selected in UI
+    chartType: QLChartType;
+    queryValue: string;
+    queries: QLQueryV2[];
+    extraSettings?: CommonSharedExtraSettings;
+    visualization: Shared['visualization'] & {highchartsId?: string};
+    params: QLParamV2[];
+    connection: QLEntryDataSharedConnectionV2;
+    order?: QLResultEntryMetadataDataColumnOrGroupV2[];
+    preview?: boolean;
+
+    colors?: Field[];
+    colorsConfig?: any;
+    labels?: Field[];
+    tooltips?: Field[];
+    shapes?: Field[];
+    shapesConfig?: ShapesConfig;
+
+    available?: Field[];
+}
+
+export interface QLPreviewTableDataColumnV2 {
+    name: string;
+}
+
+export interface QLPreviewTableDataRowV2 {
+    [key: string]: number | string | null;
+}
+
+export interface QLPreviewTableDataV2 {
+    columns?: QLPreviewTableDataColumnV2[];
+    data?: QLPreviewTableDataRowV2[];
+}

--- a/src/shared/types/language.ts
+++ b/src/shared/types/language.ts
@@ -1,0 +1,5 @@
+export type GetTranslationFn = (
+    keyset: string,
+    key: string,
+    params?: Record<string, string>,
+) => string;

--- a/src/shared/types/ql/versions.ts
+++ b/src/shared/types/ql/versions.ts
@@ -1,3 +1,5 @@
 export enum QlConfigVersions {
     V1 = '1',
+    // add required queryName field to queries
+    V2 = '2',
 }

--- a/src/ui/components/EditableText/EditableText.tsx
+++ b/src/ui/components/EditableText/EditableText.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import {TextInput, useOutsideClick} from '@gravity-ui/uikit';
+
+type WrappedTextInputProps = {
+    text: string;
+    isEdit: boolean;
+    setIsEdit: (v: boolean) => void;
+    onInputApply: EditableTextProps['onInputApply'];
+};
+const WrappedTextInput: React.FC<WrappedTextInputProps> = (props: WrappedTextInputProps) => {
+    const ref = React.useRef(null);
+    const [editableText, setEditableText] = React.useState<string>(props.text);
+
+    const handleOnOutsideClick = () => {
+        if (props.isEdit) {
+            props.setIsEdit(false);
+            props.onInputApply(editableText.trim() || props.text);
+        }
+    };
+
+    const handleOnEnterClick = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            props.setIsEdit(false);
+            props.onInputApply(editableText.trim() || props.text);
+        }
+    };
+
+    const handleOnInputUpdate = (v: string) => {
+        setEditableText(v);
+    };
+
+    const handleOnInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+        event.stopPropagation();
+    };
+
+    useOutsideClick({ref, handler: handleOnOutsideClick});
+
+    return (
+        <TextInput
+            controlProps={{onClick: handleOnInputClick}}
+            onUpdate={handleOnInputUpdate}
+            onKeyPress={handleOnEnterClick}
+            controlRef={ref}
+            size="s"
+            value={editableText}
+        />
+    );
+};
+
+type EditableTextProps = {
+    text: string;
+    textClassName: string;
+    onInputApply: (v: string) => void;
+};
+export const EditableText: React.FC<EditableTextProps> = (props: EditableTextProps) => {
+    const [isEdit, setIsEdit] = React.useState(false);
+
+    const handleOnTextClick = (event: React.MouseEvent<HTMLSpanElement>) => {
+        event.stopPropagation();
+        setIsEdit(true);
+    };
+
+    return isEdit ? (
+        <WrappedTextInput
+            text={props.text}
+            isEdit={isEdit}
+            setIsEdit={setIsEdit}
+            onInputApply={props.onInputApply}
+        />
+    ) : (
+        <div onClick={handleOnTextClick} className={props.textClassName}>
+            {props.text}
+        </div>
+    );
+};

--- a/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.scss
+++ b/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.scss
@@ -57,6 +57,10 @@
         }
     }
 
+    &__query-row-title {
+        height: 100%;
+    }
+
     &__editor-wrapper {
         resize: vertical;
         overflow: hidden;

--- a/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.scss
+++ b/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.scss
@@ -59,6 +59,10 @@
 
     &__query-row-title {
         height: 100%;
+        max-width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     &__editor-wrapper {

--- a/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.tsx
+++ b/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.tsx
@@ -21,6 +21,7 @@ import {
 } from 'ui';
 import {DL_ADAPTIVE_TABS_BREAK_POINT_CONFIG} from 'ui/constants/misc';
 
+import {EditableText} from '../../../../../../../components/EditableText/EditableText';
 import {prepareChartDataBeforeSave} from '../../../../../modules/helpers';
 import {
     addParamInQuery,
@@ -121,9 +122,19 @@ class TabQuery extends React.PureComponent<TabQueryInnerProps, TabQueryState> {
                                     className={b('query-row-collapse')}
                                     title={
                                         <div className={b('query-row-header')}>
-                                            <span className={b('query-row-title')}>
-                                                {query.queryName}
-                                            </span>
+                                            <EditableText
+                                                text={query.queryName}
+                                                textClassName={b('query-row-title')}
+                                                onInputApply={(queryName) => {
+                                                    if (queryName === query.queryName) {
+                                                        return;
+                                                    }
+                                                    this.props.updateQueryAndRedraw({
+                                                        query: {...query, queryName},
+                                                        index: queryIndex,
+                                                    });
+                                                }}
+                                            />
                                         </div>
                                     }
                                     toolbar={

--- a/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.tsx
+++ b/src/ui/units/ql/containers/PaneMain/ScreenEditor/TabQuery/ScreenPromQL/ScreenPromQL.tsx
@@ -121,10 +121,9 @@ class TabQuery extends React.PureComponent<TabQueryInnerProps, TabQueryState> {
                                     className={b('query-row-collapse')}
                                     title={
                                         <div className={b('query-row-header')}>
-                                            <span className={b('query-row-title')}>{`${i18n(
-                                                'sql',
-                                                'label_query',
-                                            )} ${queryIndex + 1}`}</span>
+                                            <span className={b('query-row-title')}>
+                                                {query.queryName}
+                                            </span>
                                         </div>
                                     }
                                     toolbar={

--- a/src/ui/units/ql/store/actions/ql.ts
+++ b/src/ui/units/ql/store/actions/ql.ts
@@ -1,6 +1,6 @@
 import {AxiosError} from 'axios';
 import {History, Location} from 'history';
-import {i18n} from 'i18n';
+import {I18n, i18n} from 'i18n';
 import _ from 'lodash';
 import type {match as Match} from 'react-router-dom';
 import {mapQlConfigToLatestVersion} from 'shared/modules/config/ql';
@@ -661,7 +661,7 @@ export const initializeApplication = (args: InitializeApplicationArgs) => {
                 if (typeof loadedEntry.data?.shared === 'string') {
                     entry.data.shared = mapQlConfigToLatestVersion(
                         JSON.parse(loadedEntry.data.shared),
-                        {i18n: getTranslationFn(i18n)},
+                        {i18n: getTranslationFn(I18n)},
                     );
                 } else {
                     throw new Error(i18n('sql', 'error_failed-to-parse-loaded-chart'));

--- a/src/ui/units/ql/store/actions/ql.ts
+++ b/src/ui/units/ql/store/actions/ql.ts
@@ -4,6 +4,7 @@ import {i18n} from 'i18n';
 import _ from 'lodash';
 import type {match as Match} from 'react-router-dom';
 import {mapQlConfigToLatestVersion} from 'shared/modules/config/ql';
+import {getTranslationFn} from 'shared/modules/language';
 import type {
     QLConfigQuery,
     QlConfig,
@@ -660,6 +661,7 @@ export const initializeApplication = (args: InitializeApplicationArgs) => {
                 if (typeof loadedEntry.data?.shared === 'string') {
                     entry.data.shared = mapQlConfigToLatestVersion(
                         JSON.parse(loadedEntry.data.shared),
+                        {i18n: getTranslationFn(i18n)},
                     );
                 } else {
                     throw new Error(i18n('sql', 'error_failed-to-parse-loaded-chart'));

--- a/src/ui/units/ql/store/reducers/ql.ts
+++ b/src/ui/units/ql/store/reducers/ql.ts
@@ -1,3 +1,4 @@
+import {i18n} from 'i18n';
 import _ from 'lodash';
 import moment from 'moment';
 import {createSelector} from 'reselect';
@@ -349,7 +350,7 @@ export const getEntryNotChanged = createSelector(
                 chartType,
                 visualization,
                 order: [],
-                version: QlConfigVersions.V1,
+                version: QlConfigVersions.V2,
             };
 
             // Removing possible functions from the structure to compare data
@@ -425,7 +426,7 @@ export const getPreviewData = createSelector(
                 params: params,
                 visualization,
                 order,
-                version: QlConfigVersions.V1,
+                version: QlConfigVersions.V2,
             };
 
             return result;
@@ -564,6 +565,7 @@ export default function ql(state: QLState = initialState, action: QLAction) {
                 {
                     value: '',
                     params: [],
+                    queryName: `${i18n('sql', 'label_query')} ${queries.length + 1}`,
                 },
             ];
 

--- a/src/ui/units/ql/store/utils/grid.ts
+++ b/src/ui/units/ql/store/utils/grid.ts
@@ -105,7 +105,7 @@ export class Helper {
                 entryId: '',
                 type: '',
             },
-            version: QlConfigVersions.V1,
+            version: QlConfigVersions.V2,
         };
 
         return {

--- a/src/ui/units/ql/store/utils/monitoring.ts
+++ b/src/ui/units/ql/store/utils/monitoring.ts
@@ -1,3 +1,4 @@
+import {i18n} from 'i18n';
 import moment from 'moment';
 import {QLConfigQuery, QlConfigParam} from 'shared/types/config/ql';
 
@@ -21,8 +22,9 @@ export const prepareMonitoringPresetV2 = (preset: MonitoringPresetV2) => {
     }
 
     if (Array.isArray(preset?.data?.widget?.queries?.targets)) {
-        preset.data.widget.queries.targets.forEach((target) => {
+        preset.data.widget.queries.targets.forEach((target, index) => {
             initialQueries.push({
+                queryName: `${i18n('sql', 'label_query')} ${index + 1}`,
                 value: target.query,
                 params: [],
             });
@@ -116,8 +118,9 @@ export const prepareMonitoringPresetV1 = (preset: MonitoringPresetV1) => {
     let visualization = getDefaultQlVisualization();
 
     if (preset?.data?.chart) {
-        preset.data.chart.targets.forEach((target) => {
+        preset.data.chart.targets.forEach((target, index) => {
             initialQueries.push({
+                queryName: `${i18n('sql', 'label_query')} ${index + 1}`,
                 value: target.query,
                 params: [
                     {


### PR DESCRIPTION
- Fix yarn tooltip bug
There was inappropriate usage of `tracking` option. It was equal to `visualizationId` or `highchartsId`, it leaded to lose user's cursor tracking when hovering over lines.  According to the type, this could only be a `'sticky'|'area'|function` value. 
- Add mapping config to version 2
QL config now supports a required queryName field. By default, the `Query [index]` construct is used.
- Add editable text component
Add component that allows to edit text value on click via replacing `div` to `Input`