### PR TITLE
Enable Inspector in menu for some types of error charts

### DIFF
--- a/src/i18n-keysets/chartkit.custom-error/en.json
+++ b/src/i18n-keysets/chartkit.custom-error/en.json
@@ -5,6 +5,7 @@
   "error": "Error",
   "error-data-provider": "Data fetching error",
   "error-no-data": "No data",
+  "error-timeout": "The server response waiting time has been exceeded",
   "error-too-many-lines": "Too many series on the chart",
   "error-unknown-extension": "Unknown chart type",
   "more": "More",

--- a/src/i18n-keysets/chartkit.custom-error/keyset.json
+++ b/src/i18n-keysets/chartkit.custom-error/keyset.json
@@ -32,6 +32,10 @@
       "en": "APPROVED",
       "ru": "APPROVED"
     },
+    "error-timeout": {
+      "en": "APPROVED",
+      "ru": "APPROVED"
+    },
     "error-too-many-lines": {
       "en": "APPROVED",
       "ru": "APPROVED"

--- a/src/i18n-keysets/chartkit.custom-error/ru.json
+++ b/src/i18n-keysets/chartkit.custom-error/ru.json
@@ -5,6 +5,7 @@
   "error": "Ошибка",
   "error-data-provider": "Ошибка загрузки данных",
   "error-no-data": "Нет данных",
+  "error-timeout": "Превышено время ожидания ответа от сервера",
   "error-too-many-lines": "Превышено рекомендуемое число рядов",
   "error-unknown-extension": "Неизвестный тип чарта",
   "more": "Подробнее",

--- a/src/ui/libs/DatalensChartkit/Error/Error.scss
+++ b/src/ui/libs/DatalensChartkit/Error/Error.scss
@@ -20,6 +20,7 @@ $monospaceFontFamily: 'Consolas', 'Menlo', 'Ubuntu Mono', monospace;
     & &__icon {
         color: var(--g-color-text-danger);
         margin-right: 8px;
+        flex-shrink: 0;
 
         &_no-data {
             color: var(--g-color-base-neutral-heavy);

--- a/src/ui/libs/DatalensChartkit/components/ChartKitBase/components/Header/components/Menu/Menu.js
+++ b/src/ui/libs/DatalensChartkit/components/ChartKitBase/components/Header/components/Menu/Menu.js
@@ -188,6 +188,7 @@ export class Menu extends React.PureComponent {
                   widgetRenderTimeRef,
                   callbackOnCommentsChanged,
                   updatedCommentsLength: commentsLength,
+                  error,
               })
             : items;
 

--- a/src/ui/libs/DatalensChartkit/modules/datalens-chartkit-custom-error/datalens-chartkit-custom-error.ts
+++ b/src/ui/libs/DatalensChartkit/modules/datalens-chartkit-custom-error/datalens-chartkit-custom-error.ts
@@ -182,7 +182,11 @@ function formatError({
                 });
                 break;
             case ERROR_CODE.UNKNOWN_ERROR:
-                message = i18n('chartkit.custom-error', 'error');
+                message =
+                    debug.status === 504
+                        ? i18n('chartkit.custom-error', 'error-timeout')
+                        : i18n('chartkit.custom-error', 'error');
+
                 Object.assign(details, {message: originalError.message});
                 break;
         }


### PR DESCRIPTION
- The inspector is visible for errors that have information about the source
- Add text message for timeout errors 