### PR TITLE
Fix QL chart params default value check, when it is empty string

### DIFF
--- a/src/server/modes/charts/plugins/ql/utils/misc-helpers.ts
+++ b/src/server/modes/charts/plugins/ql/utils/misc-helpers.ts
@@ -467,7 +467,7 @@ export function buildSource({
         // For the rest - we leave the text as it is, we pass the parameters to the back.
         Object.keys(params).forEach((key) => {
             const paramDescription = paramsDescription.find((param) => param.name === key);
-            if (paramDescription && paramDescription.defaultValue) {
+            if (paramDescription?.defaultValue !== undefined) {
                 if (
                     paramDescription.type === QLParamType.DateInterval ||
                     paramDescription.type === QLParamType.DatetimeInterval


### PR DESCRIPTION
Seems that empty string value is valid, chart returns `No data` in that case, but previously this case was not handled because of simple check for _falsy_ value
```javascript
if (paramDescription && paramDescription.defaultValue) {
    ...
}
```


Since by type defaultValue might be only `string | string[] | {from, to} | undefined` I suggest to check that defaultValue not equal undefined value.