### PR TITLE
Fix naming for extending value selector

### DIFF
--- a/src/ui/registry/units/dash/functions-map.ts
+++ b/src/ui/registry/units/dash/functions-map.ts
@@ -16,7 +16,7 @@ export const dashFunctionsMap = {
     getNewDashUrl: makeFunctionTemplate<(workbookId?: string) => string>(),
     getMinAutoupdateInterval: makeFunctionTemplate<() => number>(),
     getExtendedItemData: makeFunctionTemplate<(args: SetItemDataArgs) => SetItemDataArgs>(),
-    getExtendedValueSelector:
+    useExtendedValueSelector:
         makeFunctionTemplate<
             (controlType: SelectorElementType | undefined) => ReactElement | null
         >(),

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ValueSelector/ValueSelector.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ValueSelector/ValueSelector.tsx
@@ -177,9 +177,9 @@ const CheckboxValueControl = () => {
 const ValueSelector: React.FC = () => {
     const controlType = useSelector(selectSelectorControlType);
 
-    const {getExtendedValueSelector} = registry.dash.functions.getAll();
+    const {useExtendedValueSelector} = registry.dash.functions.getAll();
 
-    let inputControl = getExtendedValueSelector(controlType);
+    let inputControl = useExtendedValueSelector(controlType);
 
     if (inputControl) {
         return inputControl;


### PR DESCRIPTION
Fix naming for function that allows to extend value selector component. 

Semantically it seems more correct to use a hook naming starting with `use`. This also allows redux to be used internally (semantically)