### PR TITLE
Update postcss to 8.4.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "object-hash": "^2.2.0",
         "pixelmatch": "^5.2.1",
         "pngjs": "^6.0.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.4.33",
         "prettier": "^2.6.0",
         "prop-types": "^15.8.0",
         "react-copy-to-clipboard": "^5.0.3",
@@ -23111,16 +23111,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -23956,9 +23955,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -23974,7 +23973,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "object-hash": "^2.2.0",
     "pixelmatch": "^5.2.1",
     "pngjs": "^6.0.0",
-    "postcss": "^8.4.31",
+    "postcss": "^8.4.33",
     "prettier": "^2.6.0",
     "prop-types": "^15.8.0",
     "react-copy-to-clipboard": "^5.0.3",


### PR DESCRIPTION
postcss update:
- Fixed \r parsing to fix [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j).