### PR TITLE
Add support autofilling QL visualization colors placeholder by distincts, when multiple colors received

### DIFF
--- a/src/server/modes/charts/plugins/ql/utils/autofill-helpers.ts
+++ b/src/server/modes/charts/plugins/ql/utils/autofill-helpers.ts
@@ -1,8 +1,14 @@
 import {DATASET_FIELD_TYPES, DatasetFieldType, Field} from '../../../../../../shared';
 
-import {QUERY_ALIAS_TITLE, QUERY_TITLE} from './constants';
+import {getColorFieldsFromDistincts} from './colors';
 
-export const autofillLineVisualization = ({fields}: {fields: Field[]}) => {
+export const autofillLineVisualization = ({
+    fields,
+    distinctsMap,
+}: {
+    fields: Field[];
+    distinctsMap?: Record<string, string[]>;
+}): {xFields: Field[]; yFields: Field[]; colors?: Field[]} => {
     const yIndexes: number[] = [];
     const findNewYIndex = () =>
         fields.findIndex(
@@ -33,22 +39,11 @@ export const autofillLineVisualization = ({fields}: {fields: Field[]}) => {
         yFields.push(fields[index]);
     });
 
-    let colorIndex = fields.findIndex((column) => column.title === QUERY_ALIAS_TITLE);
-
-    if (colorIndex === -1) {
-        colorIndex = fields.findIndex((column) => column.title === QUERY_TITLE);
-    }
-
-    const result: {xFields: Field[]; yFields: Field[]; colors?: Field[]} = {
+    return {
         xFields,
         yFields,
+        colors: getColorFieldsFromDistincts(distinctsMap, fields, [...xFields, ...yFields]),
     };
-
-    if (colorIndex > -1) {
-        result.colors = [fields[colorIndex]];
-    }
-
-    return result;
 };
 
 export const autofillScatterVisualization = ({fields}: {fields: Field[]}) => {

--- a/src/server/modes/charts/plugins/ql/utils/visualization-utils.ts
+++ b/src/server/modes/charts/plugins/ql/utils/visualization-utils.ts
@@ -24,12 +24,15 @@ export const migrateOrAutofillVisualization = ({
     rows,
     order,
     colors: originalColors,
+    distinctsMap,
 }: {
     visualization: ServerVisualization;
     fields: Field[];
     rows: string[][];
     order?: QlConfigResultEntryMetadataDataColumnOrGroup[] | null;
     colors?: Field[];
+    // distincts are optional and is used only for visualization which supports multiple color fields in section
+    distinctsMap?: Record<string, string[]>;
 }) => {
     const {id: visualizationId} = originalVisualization;
 
@@ -69,6 +72,7 @@ export const migrateOrAutofillVisualization = ({
             // Old order was not set, so we can do autofill
             const {xFields, yFields, colors} = autofillLineVisualization({
                 fields,
+                distinctsMap,
             });
 
             newVisualization.placeholders[0].items = xFields;


### PR DESCRIPTION
In a previous PR, we supported the addition of multiple fields in the Colors section. 

In this PR, I'm adding support for autocompleting the section with multiple fields, based on labels when creating new charts