### PR TITLE
Fix save button behaviour for QL charts

### DIFF
--- a/src/ui/units/ql/store/actions/ql.ts
+++ b/src/ui/units/ql/store/actions/ql.ts
@@ -61,7 +61,7 @@ import {
     VisualizationStatus,
 } from '../../constants';
 import {prepareChartDataBeforeSave} from '../../modules/helpers';
-import {getAvailableQlVisualizations, getDefaultQlVisualization} from '../../utils/visualization';
+import {getDefaultQlVisualization, getQlVisualization} from '../../utils/visualization';
 import {
     getEntry,
     getGridSchemes,
@@ -789,10 +789,7 @@ export const initializeApplication = (args: InitializeApplicationArgs) => {
                 const fixedVisualizationId =
                     loadedVisualizationId === 'table' ? 'flatTable' : loadedVisualizationId;
 
-                const availableVisualizations = getAvailableQlVisualizations();
-                const visualization = (availableVisualizations.find((someVisualization) => {
-                    return someVisualization.id === fixedVisualizationId;
-                }) || getDefaultQlVisualization()) as Shared['visualization'];
+                const visualization = getQlVisualization(fixedVisualizationId, loadedVisualization);
 
                 dispatch(
                     setVisualizationWizard({

--- a/src/ui/units/ql/store/actions/ql.ts
+++ b/src/ui/units/ql/store/actions/ql.ts
@@ -741,8 +741,7 @@ export const initializeApplication = (args: InitializeApplicationArgs) => {
                 const loadedVisualization = entry.data.shared
                     .visualization as Shared['visualization'];
 
-                const {id: loadedVisualizationId, placeholders: loadedVisualizationPlaceholders} =
-                    loadedVisualization;
+                const {placeholders: loadedVisualizationPlaceholders} = loadedVisualization;
 
                 // Clone the parameters so as not to transform them into entry
                 const params = entry.data.shared.params
@@ -786,10 +785,7 @@ export const initializeApplication = (args: InitializeApplicationArgs) => {
 
                 dispatch(setWizardExtraSettings(extraSettings));
 
-                const fixedVisualizationId =
-                    loadedVisualizationId === 'table' ? 'flatTable' : loadedVisualizationId;
-
-                const visualization = getQlVisualization(fixedVisualizationId, loadedVisualization);
+                const visualization = getQlVisualization(loadedVisualization);
 
                 dispatch(
                     setVisualizationWizard({

--- a/src/ui/units/ql/utils/__tests__/getQlVisualization.test.ts
+++ b/src/ui/units/ql/utils/__tests__/getQlVisualization.test.ts
@@ -1,0 +1,62 @@
+import {
+    getAvailableQlVisualizations,
+    getDefaultQlVisualization,
+    getQlVisualization,
+} from '../visualization';
+
+import {
+    MOCKED_DEFAULT_VISUALIZATION,
+    MOCKED_INVALID_VISUALIZATION,
+    MOCKED_LOADED_VISUALIZATION,
+    MOCKED_LOADED_VISUALIZATION_WITH_PLACEHOLDERS,
+    MOCKED_PREDEFINED_VISUALIZATION,
+    MOCKED_PREDEFINED_VISUALIZATION_WITH_OVERRIDE,
+} from './mocks/getQlVisualization';
+
+jest.mock('../visualization/getAvailableQlVisualizations', () => {
+    return {
+        getAvailableQlVisualizations: jest.fn(),
+    };
+});
+
+jest.mock('../visualization/getDefaultQlVisualization', () => {
+    return {
+        getDefaultQlVisualization: jest.fn(),
+    };
+});
+
+const getAvailableQlVisualizationsMock = getAvailableQlVisualizations as jest.Mock;
+const getDefaultQlVisualizationMock = getDefaultQlVisualization as jest.Mock;
+
+describe('getQlVisualization', () => {
+    beforeEach(() => {
+        getAvailableQlVisualizationsMock.mockImplementationOnce(() => [
+            MOCKED_PREDEFINED_VISUALIZATION,
+        ]);
+    });
+    it('should merge properties of predefined visualization and loaded visualization', () => {
+        const result = getQlVisualization(MOCKED_LOADED_VISUALIZATION);
+
+        expect(result).toStrictEqual({...MOCKED_PREDEFINED_VISUALIZATION, colorsCapacity: 1});
+    });
+
+    it('should not override already defined properties in predefined visualization', () => {
+        const result = getQlVisualization(MOCKED_PREDEFINED_VISUALIZATION_WITH_OVERRIDE);
+
+        expect(result.allowLabels).toStrictEqual(false);
+    });
+
+    it('should leave default value for placeholders from predefined visualization', () => {
+        const result = getQlVisualization(MOCKED_LOADED_VISUALIZATION_WITH_PLACEHOLDERS);
+
+        expect(result).toStrictEqual(MOCKED_PREDEFINED_VISUALIZATION);
+    });
+
+    it('should return default visualization, when id does not match with availableVisualizations', () => {
+        getDefaultQlVisualizationMock.mockImplementationOnce(() => MOCKED_DEFAULT_VISUALIZATION);
+
+        const result = getQlVisualization(MOCKED_INVALID_VISUALIZATION);
+
+        expect(result).toStrictEqual(MOCKED_DEFAULT_VISUALIZATION);
+    });
+});

--- a/src/ui/units/ql/utils/__tests__/mocks/getQlVisualization.ts
+++ b/src/ui/units/ql/utils/__tests__/mocks/getQlVisualization.ts
@@ -1,0 +1,41 @@
+import type {Shared} from 'shared';
+
+export const MOCKED_PREDEFINED_VISUALIZATION = {
+    id: 'column',
+    placeholders: [],
+    allowColors: true,
+    allowLabels: false,
+} as unknown as Shared['visualization'];
+
+export const MOCKED_DEFAULT_VISUALIZATION = {
+    id: 'column',
+    placeholders: [],
+    allowColors: true,
+    allowLabels: true,
+    colorsCapacity: 1,
+} as unknown as Shared['visualization'];
+
+export const MOCKED_LOADED_VISUALIZATION = {
+    id: 'column',
+    placeholders: [],
+    allowColors: true,
+    colorsCapacity: 1,
+} as unknown as Shared['visualization'];
+
+export const MOCKED_PREDEFINED_VISUALIZATION_WITH_OVERRIDE = {
+    id: 'column',
+    placeholders: [],
+    allowColors: true,
+    allowLabels: true,
+} as unknown as Shared['visualization'];
+
+export const MOCKED_LOADED_VISUALIZATION_WITH_PLACEHOLDERS = {
+    id: 'column',
+    placeholders: [{id: 'x', items: [{guid: 'x-field'}]}],
+    allowColors: true,
+} as unknown as Shared['visualization'];
+
+export const MOCKED_INVALID_VISUALIZATION = {
+    id: 'invalid_id',
+    placeholders: [],
+} as unknown as Shared['visualization'];

--- a/src/ui/units/ql/utils/visualization.ts
+++ b/src/ui/units/ql/utils/visualization.ts
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
+import merge from 'lodash/merge';
 
 import {ChartkitGlobalSettings, Placeholder, Shared} from '../../../../shared';
 import {DL} from '../../../constants';
@@ -22,7 +23,9 @@ import {
 } from '../../../constants/visualizations';
 import {DEFAULT_VISUALIZATION_ID_QL} from '../constants';
 
-export function getAvailableQlVisualizations(options?: ChartkitGlobalSettings) {
+export function getAvailableQlVisualizations(
+    options?: ChartkitGlobalSettings,
+): Array<Shared['visualization']> {
     const {highcharts: {enabled: isHighchartsEnabled = false} = {}} =
         options || DL.CHARTKIT_SETTINGS;
 
@@ -123,3 +126,18 @@ export function getDefaultQlVisualization(): Shared['visualization'] {
         ) || availableVisualizations[0]
     );
 }
+
+export const getQlVisualization = (
+    visualizationId: string,
+    loadedVisualization: Shared['visualization'],
+): Shared['visualization'] => {
+    const availableVisualizations = getAvailableQlVisualizations();
+
+    const candidate = availableVisualizations.find((vis) => vis.id === visualizationId);
+
+    if (candidate) {
+        return merge({}, candidate, loadedVisualization);
+    } else {
+        return getDefaultQlVisualization();
+    }
+};

--- a/src/ui/units/ql/utils/visualization/getAvailableQlVisualizations.ts
+++ b/src/ui/units/ql/utils/visualization/getAvailableQlVisualizations.ts
@@ -1,8 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
-import merge from 'lodash/merge';
+import {ChartkitGlobalSettings, Placeholder, Shared} from 'shared';
+import {DL} from 'ui/constants/common';
 
-import {ChartkitGlobalSettings, Placeholder, Shared} from '../../../../shared';
-import {DL} from '../../../constants';
 import {
     AREA_100P_VISUALIZATION,
     AREA_VISUALIZATION,
@@ -20,8 +19,7 @@ import {
     SCATTER_D3_VISUALIZATION,
     SCATTER_VISUALIZATION,
     TREEMAP_VISUALIZATION,
-} from '../../../constants/visualizations';
-import {DEFAULT_VISUALIZATION_ID_QL} from '../constants';
+} from '../../../../constants/visualizations';
 
 export function getAvailableQlVisualizations(
     options?: ChartkitGlobalSettings,
@@ -115,29 +113,3 @@ export function getAvailableQlVisualizations(
         },
     );
 }
-
-export function getDefaultQlVisualization(): Shared['visualization'] {
-    const availableVisualizations = getAvailableQlVisualizations();
-
-    // We use column chart as initial visualization type in QL and Wizard
-    return (
-        availableVisualizations.find(
-            (visualization) => visualization.id === DEFAULT_VISUALIZATION_ID_QL,
-        ) || availableVisualizations[0]
-    );
-}
-
-export const getQlVisualization = (
-    visualizationId: string,
-    loadedVisualization: Shared['visualization'],
-): Shared['visualization'] => {
-    const availableVisualizations = getAvailableQlVisualizations();
-
-    const candidate = availableVisualizations.find((vis) => vis.id === visualizationId);
-
-    if (candidate) {
-        return merge({}, candidate, loadedVisualization);
-    } else {
-        return getDefaultQlVisualization();
-    }
-};

--- a/src/ui/units/ql/utils/visualization/getDefaultQlVisualization.ts
+++ b/src/ui/units/ql/utils/visualization/getDefaultQlVisualization.ts
@@ -1,0 +1,16 @@
+import {Shared} from 'shared';
+
+import {DEFAULT_VISUALIZATION_ID_QL} from '../../constants';
+
+import {getAvailableQlVisualizations} from './getAvailableQlVisualizations';
+
+export function getDefaultQlVisualization(): Shared['visualization'] {
+    const availableVisualizations = getAvailableQlVisualizations();
+
+    // We use column chart as initial visualization type in QL and Wizard
+    return (
+        availableVisualizations.find(
+            (visualization) => visualization.id === DEFAULT_VISUALIZATION_ID_QL,
+        ) || availableVisualizations[0]
+    );
+}

--- a/src/ui/units/ql/utils/visualization/getQlVisualization.ts
+++ b/src/ui/units/ql/utils/visualization/getQlVisualization.ts
@@ -4,9 +4,10 @@ import {Shared} from 'shared';
 import {getAvailableQlVisualizations, getDefaultQlVisualization} from '../visualization';
 
 export const getQlVisualization = (
-    visualizationId: string,
     loadedVisualization: Shared['visualization'],
 ): Shared['visualization'] => {
+    const visualizationId =
+        loadedVisualization.id === 'table' ? 'flatTable' : loadedVisualization.id;
     const availableVisualizations = getAvailableQlVisualizations();
 
     const candidate = availableVisualizations.find((vis) => vis.id === visualizationId);
@@ -23,10 +24,10 @@ export const getQlVisualization = (
                 obj: Shared['visualization'] | {},
                 source: Shared['visualization'],
             ) => {
+                // it needs to prevent override properties which already defined in candidate visualization
                 if (
-                    key === 'placeholders' &&
-                    Object.hasOwnProperty.call(obj, 'placeholders') &&
-                    Object.hasOwnProperty.call(source, 'placeholders')
+                    Object.hasOwnProperty.call(obj, key) &&
+                    Object.hasOwnProperty.call(source, key)
                 ) {
                     return value;
                 }

--- a/src/ui/units/ql/utils/visualization/getQlVisualization.ts
+++ b/src/ui/units/ql/utils/visualization/getQlVisualization.ts
@@ -1,5 +1,5 @@
 import mergeWith from 'lodash/mergeWith';
-import {Shared} from 'shared';
+import {QlVisualizationId, Shared, WizardVisualizationId} from 'shared';
 
 import {getAvailableQlVisualizations, getDefaultQlVisualization} from '../visualization';
 
@@ -7,7 +7,9 @@ export const getQlVisualization = (
     loadedVisualization: Shared['visualization'],
 ): Shared['visualization'] => {
     const visualizationId =
-        loadedVisualization.id === 'table' ? 'flatTable' : loadedVisualization.id;
+        loadedVisualization.id === QlVisualizationId.FlatTable
+            ? WizardVisualizationId.FlatTable
+            : loadedVisualization.id;
     const availableVisualizations = getAvailableQlVisualizations();
 
     const candidate = availableVisualizations.find((vis) => vis.id === visualizationId);
@@ -24,7 +26,7 @@ export const getQlVisualization = (
                 obj: Shared['visualization'] | {},
                 source: Shared['visualization'],
             ) => {
-                // it needs to prevent override properties which already defined in candidate visualization
+                // It needs to prevent override properties which already defined in candidate visualization
                 if (
                     Object.hasOwnProperty.call(obj, key) &&
                     Object.hasOwnProperty.call(source, key)

--- a/src/ui/units/ql/utils/visualization/getQlVisualization.ts
+++ b/src/ui/units/ql/utils/visualization/getQlVisualization.ts
@@ -1,0 +1,40 @@
+import mergeWith from 'lodash/mergeWith';
+import {Shared} from 'shared';
+
+import {getAvailableQlVisualizations, getDefaultQlVisualization} from '../visualization';
+
+export const getQlVisualization = (
+    visualizationId: string,
+    loadedVisualization: Shared['visualization'],
+): Shared['visualization'] => {
+    const availableVisualizations = getAvailableQlVisualizations();
+
+    const candidate = availableVisualizations.find((vis) => vis.id === visualizationId);
+
+    if (candidate) {
+        return mergeWith(
+            {},
+            candidate,
+            loadedVisualization,
+            (
+                value: any,
+                _sourceValue: any,
+                key,
+                obj: Shared['visualization'] | {},
+                source: Shared['visualization'],
+            ) => {
+                if (
+                    key === 'placeholders' &&
+                    Object.hasOwnProperty.call(obj, 'placeholders') &&
+                    Object.hasOwnProperty.call(source, 'placeholders')
+                ) {
+                    return value;
+                }
+
+                return undefined;
+            },
+        );
+    } else {
+        return getDefaultQlVisualization();
+    }
+};

--- a/src/ui/units/ql/utils/visualization/index.ts
+++ b/src/ui/units/ql/utils/visualization/index.ts
@@ -1,0 +1,3 @@
+export {getQlVisualization} from './getQlVisualization';
+export {getAvailableQlVisualizations} from './getAvailableQlVisualizations';
+export {getDefaultQlVisualization} from './getDefaultQlVisualization';


### PR DESCRIPTION
Now, when a visualization object is loaded in a QL chart, a predefined value is stamped into the repository. However, some fields may not be in the predefined value. 

For this, I added adding fields from the loaded visualization that are not in the predefined visualization