### PR TITLE
Fix setting local storage value, when mount the component

### DIFF
--- a/src/ui/units/dash/containers/Body/Body.tsx
+++ b/src/ui/units/dash/containers/Body/Body.tsx
@@ -156,6 +156,9 @@ class Body extends React.PureComponent<BodyProps> {
     };
 
     componentDidMount() {
+        // if localStorage already have a dash item, we need to set it to state
+        this.storageHandler();
+
         window.addEventListener('storage', this.storageHandler);
     }
 


### PR DESCRIPTION
For this moment the state value updates only when "storage" event is fired. 

This [event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event) works only for other browser tabs that allows to copy widgets between them. But for now it's not possible to copy widget to other dashboard within one browser tab. 

It might be fixed if we will set default value to state from localStorage, when mounting a dashboard body. 