### PR TITLE
Add support basic tab for new connection based control

### DIFF
--- a/src/server/components/features/features-list/ConnectionBasedControl.ts
+++ b/src/server/components/features/features-list/ConnectionBasedControl.ts
@@ -4,7 +4,7 @@ import {createFeatureConfig} from '../utils';
 export default createFeatureConfig({
     name: Feature.ConnectionBasedControl,
     state: {
-        development: true,
+        development: false,
         production: false,
     },
 });

--- a/src/server/components/features/features-list/ConnectionBasedControl.ts
+++ b/src/server/components/features/features-list/ConnectionBasedControl.ts
@@ -1,0 +1,10 @@
+import {Feature} from '../../../../shared';
+import {createFeatureConfig} from '../utils';
+
+export default createFeatureConfig({
+    name: Feature.ConnectionBasedControl,
+    state: {
+        development: true,
+        production: false,
+    },
+});

--- a/src/shared/types/dash.ts
+++ b/src/shared/types/dash.ts
@@ -19,6 +19,7 @@ export enum DashTabItemTitleSize {
 
 export enum DashTabItemControlSourceType {
     Dataset = 'dataset',
+    Connection = 'connection',
     Manual = 'manual',
     External = 'external',
 }

--- a/src/shared/types/feature.ts
+++ b/src/shared/types/feature.ts
@@ -75,6 +75,7 @@ export enum Feature {
     SelectorRequiredValue = 'SelectorRequiredValue',
     MultipleColorsInVisualization = 'MultipleColorsInVisualization',
     MarkupMetric = 'MarkupMetric',
+    ConnectionBasedControl = 'ConnectionBasedControl',
 }
 
 export type FeatureConfig = Record<string, boolean>;

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/AppearanceSection/Rows/InnerTitleRow/InnerTitleRow.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/AppearanceSection/Rows/InnerTitleRow/InnerTitleRow.tsx
@@ -5,13 +5,14 @@ import {Checkbox, TextInput} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
 import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
-import {ControlQA, DialogControlQa} from 'shared';
+import {ControlQA, DashTabItemControlSourceType, DialogControlQa} from 'shared';
 import {setSelectorDialogItem} from 'units/dash/store/actions/dashTyped';
 import {
     selectIsDatasetSelectorAndNoFieldSelected,
     selectSelectorDialog,
 } from 'units/dash/store/selectors/dashTypedSelectors';
 
+import type {SelectorSourceType} from '../../../../../../../store/actions/controls/types';
 import {ELEMENT_TYPE} from '../../../../../Control/constants';
 
 import '../../AppearanceSection.scss';
@@ -19,10 +20,20 @@ import '../../AppearanceSection.scss';
 const b = block('control2-appearance-section');
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
+const i18nConnectionBasedControlFake = (str: string) => str;
+
+const getHelpPopoverText = (sourceType: SelectorSourceType | undefined): string => {
+    switch (sourceType) {
+        case DashTabItemControlSourceType.Connection:
+            return i18nConnectionBasedControlFake('field_inner-title-note-connection-selector');
+        default:
+            return i18n('field_inner-title-note');
+    }
+};
 
 export const InnerTitleRow = () => {
     const dispatch = useDispatch();
-    const {elementType, showInnerTitle, innerTitle} = useSelector(selectSelectorDialog);
+    const {elementType, showInnerTitle, innerTitle, sourceType} = useSelector(selectSelectorDialog);
     const isFieldDisabled = useSelector(selectIsDatasetSelectorAndNoFieldSelected);
 
     const isInnerTitleDisabled = elementType === ELEMENT_TYPE.CHECKBOX || isFieldDisabled;
@@ -48,7 +59,7 @@ export const InnerTitleRow = () => {
         <React.Fragment>
             <span>{i18n('field_inner-title')}</span>
             <HelpPopover
-                htmlContent={i18n('field_inner-title-note')}
+                htmlContent={getHelpPopoverText(sourceType)}
                 placement={['bottom', 'top']}
                 offset={{top: -1, left: 5}}
             />

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/CommonSettingsSection.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/CommonSettingsSection.tsx
@@ -4,6 +4,7 @@ import {useSelector} from 'react-redux';
 import {DashTabItemControlSourceType} from 'shared';
 import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
 
+import {ConnectionSettings} from './ConnectionSettings/ConnectionSettings';
 import {DatasetSettings} from './DatasetSettings/DatasetSettings';
 import {ExternalSelectorSettings} from './ExternalSelectorSettings/ExternalSelectorSettings';
 import {InputSettings} from './InputSettings/InputSettings';
@@ -20,6 +21,8 @@ const CommonSettingsSection = ({isSectionHidden}: CommonSettingsProps) => {
             return <ExternalSelectorSettings />;
         case DashTabItemControlSourceType.Manual:
             return <InputSettings isSectionHidden={isSectionHidden} />;
+        case DashTabItemControlSourceType.Connection:
+            return <ConnectionSettings />;
         default:
             return <DatasetSettings isSectionHidden={isSectionHidden} />;
     }

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -3,8 +3,25 @@ import React from 'react';
 import {I18n} from 'i18n';
 
 import {SectionWrapper} from '../../../../../../../../components/SectionWrapper/SectionWrapper';
+import {ELEMENT_TYPE} from '../../../../Control/constants';
+import {ValueSelector} from '../../ValueSelector/ValueSelector';
+import {InputTypeSelector} from '../InputTypeSelector/InputTypeSelector';
+import {getElementOptions} from '../helpers/input-type-select';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
 export const ConnectionSettings: React.FC = () => {
-    return <SectionWrapper title={i18n('label_common-settings')}></SectionWrapper>;
+    const options = React.useMemo(() => {
+        const allowedOptions: Record<string, boolean> = {
+            [ELEMENT_TYPE.SELECT]: true,
+            [ELEMENT_TYPE.INPUT]: true,
+        };
+        return getElementOptions().filter((v) => allowedOptions[v.value]);
+    }, []);
+
+    return (
+        <SectionWrapper title={i18n('label_common-settings')}>
+            <InputTypeSelector options={options} />
+            <ValueSelector />
+        </SectionWrapper>
+    );
 };

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import {I18n} from 'i18n';
+
+import {SectionWrapper} from '../../../../../../../../components/SectionWrapper/SectionWrapper';
+
+const i18n = I18n.keyset('dash.control-dialog.edit');
+export const ConnectionSettings: React.FC = () => {
+    return <SectionWrapper title={i18n('label_common-settings')}></SectionWrapper>;
+};

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -15,7 +15,7 @@ export const ConnectionSettings: React.FC = () => {
             [ELEMENT_TYPE.SELECT]: true,
             [ELEMENT_TYPE.INPUT]: true,
         };
-        return getElementOptions().filter((v) => allowedOptions[v.value]);
+        return getElementOptions().filter(({value}) => allowedOptions[value]);
     }, []);
 
     return (

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/DatasetSettings/DatasetSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/DatasetSettings/DatasetSettings.tsx
@@ -39,7 +39,10 @@ const DatasetSettings = ({isSectionHidden}: DatasetSettingsProps) => {
                 sourceType === DashTabItemControlSourceType.Dataset &&
                 fieldType !== DATASET_FIELD_TYPES.BOOLEAN,
         };
-        return getElementOptions().map((v) => ({...v, disabled: disabledOptions[v.value]}));
+        return getElementOptions().map((option) => ({
+            ...option,
+            disabled: disabledOptions[option.value],
+        }));
     }, [sourceType, fieldType, controlType, datasetFieldType]);
 
     return (

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/DatasetSettings/DatasetSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/DatasetSettings/DatasetSettings.tsx
@@ -25,8 +25,8 @@ type DatasetSettingsProps = {
 const DatasetSettings = ({isSectionHidden}: DatasetSettingsProps) => {
     const {datasetFieldType, sourceType, fieldType} = useSelector(selectSelectorDialog);
     const controlType = useSelector(selectSelectorControlType);
-    const disabledOptions: Record<string, boolean> = React.useMemo(
-        () => ({
+    const options = React.useMemo(() => {
+        const disabledOptions: Record<string, boolean> = {
             [ELEMENT_TYPE.DATE]:
                 sourceType === DashTabItemControlSourceType.Dataset &&
                 ((controlType !== ELEMENT_TYPE.DATE &&
@@ -38,13 +38,9 @@ const DatasetSettings = ({isSectionHidden}: DatasetSettingsProps) => {
             [ELEMENT_TYPE.CHECKBOX]:
                 sourceType === DashTabItemControlSourceType.Dataset &&
                 fieldType !== DATASET_FIELD_TYPES.BOOLEAN,
-        }),
-        [sourceType, fieldType, controlType, datasetFieldType],
-    );
-
-    const options = React.useMemo(() => {
+        };
         return getElementOptions().map((v) => ({...v, disabled: disabledOptions[v.value]}));
-    }, [disabledOptions]);
+    }, [sourceType, fieldType, controlType, datasetFieldType]);
 
     return (
         <React.Fragment>

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/InputSettings/InputSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/InputSettings/InputSettings.tsx
@@ -13,6 +13,7 @@ import {SectionWrapper} from '../../../../../../../../components/SectionWrapper/
 import {OperationSelector} from '../../OperationSelector/OperationSelector';
 import {ValueSelector} from '../../ValueSelector/ValueSelector';
 import {InputTypeSelector} from '../InputTypeSelector/InputTypeSelector';
+import {getElementOptions} from '../helpers/input-type-select';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
 
@@ -34,6 +35,10 @@ const InputSettings = ({isSectionHidden}: InputSettingsProps) => {
 
     const value = fieldName ?? '';
 
+    const options = React.useMemo(() => {
+        return getElementOptions();
+    }, []);
+
     return (
         <React.Fragment>
             <SectionWrapper
@@ -49,7 +54,7 @@ const InputSettings = ({isSectionHidden}: InputSettingsProps) => {
                         />
                     </FieldWrapper>
                 </FormRow>
-                <InputTypeSelector />
+                <InputTypeSelector options={options} />
                 <OperationSelector />
                 <ValueSelector />
             </SectionWrapper>

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/InputTypeSelector/InputTypeSelector.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/InputTypeSelector/InputTypeSelector.tsx
@@ -1,68 +1,31 @@
 import React from 'react';
 
 import {FormRow} from '@gravity-ui/components';
-import {Calendar, FontCursor, ListUl, SquareCheck} from '@gravity-ui/icons';
-import {Icon, Select, SelectOption} from '@gravity-ui/uikit';
+import {Select, SelectOption} from '@gravity-ui/uikit';
 import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
-import {
-    DATASET_FIELD_TYPES,
-    DashTabItemControlSourceType,
-    DatasetFieldType,
-    DialogControlQa,
-} from 'shared';
+import {DialogControlQa} from 'shared';
 import {SelectOptionWithIcon} from 'ui/components/SelectComponents/components/SelectOptionWithIcon/SelectOptionWithIcon';
-import {ELEMENT_TYPE} from 'units/dash/containers/Dialogs/Control/constants';
 import {SelectorElementType, setSelectorDialogItem} from 'units/dash/store/actions/dashTyped';
 import {
     selectIsDatasetSelectorAndNoFieldSelected,
     selectSelectorControlType,
-    selectSelectorDialog,
 } from 'units/dash/store/selectors/dashTypedSelectors';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
 
 const renderOptions = (option: SelectOption) => <SelectOptionWithIcon option={option} />;
 
-const getElementOptions = (disabledOptions: Record<string, boolean>) => [
-    {
-        value: ELEMENT_TYPE.SELECT,
-        content: i18n('value_element-select'),
-        disabled: disabledOptions[ELEMENT_TYPE.SELECT],
-        data: {
-            icon: <Icon data={ListUl} />,
-        },
-    },
-    {
-        value: ELEMENT_TYPE.INPUT,
-        content: i18n('value_element-input'),
-        data: {
-            icon: <Icon data={FontCursor} />,
-        },
-    },
-    {
-        value: ELEMENT_TYPE.DATE,
-        content: i18n('value_element-date'),
-        disabled: disabledOptions[ELEMENT_TYPE.DATE],
-        data: {
-            icon: <Icon data={Calendar} />,
-        },
-    },
-    {
-        value: ELEMENT_TYPE.CHECKBOX,
-        content: i18n('value_element-checkbox'),
-        disabled: disabledOptions[ELEMENT_TYPE.CHECKBOX],
-        data: {
-            icon: <Icon data={SquareCheck} />,
-        },
-    },
-];
+type InputTypeSelectorProps = {
+    options: SelectOption[];
+};
 
-const InputTypeSelector = () => {
+const InputTypeSelector: React.FC<InputTypeSelectorProps> = (props: InputTypeSelectorProps) => {
     const dispatch = useDispatch();
-    const {datasetFieldType, sourceType, fieldType} = useSelector(selectSelectorDialog);
     const controlType = useSelector(selectSelectorControlType);
     const isFieldDisabled = useSelector(selectIsDatasetSelectorAndNoFieldSelected);
+
+    const {options} = props;
 
     const handleInputTypeChange = React.useCallback(
         (value: string[]) => {
@@ -74,25 +37,6 @@ const InputTypeSelector = () => {
         },
         [dispatch],
     );
-
-    const disabledOptions = React.useMemo(
-        () => ({
-            [ELEMENT_TYPE.DATE]:
-                sourceType === DashTabItemControlSourceType.Dataset &&
-                ((controlType !== ELEMENT_TYPE.DATE &&
-                    fieldType !== DATASET_FIELD_TYPES.DATE &&
-                    fieldType !== DATASET_FIELD_TYPES.DATETIME &&
-                    fieldType !== DATASET_FIELD_TYPES.GENERICDATETIME) ||
-                    datasetFieldType === DatasetFieldType.Measure),
-            [ELEMENT_TYPE.SELECT]: datasetFieldType === DatasetFieldType.Measure,
-            [ELEMENT_TYPE.CHECKBOX]:
-                sourceType === DashTabItemControlSourceType.Dataset &&
-                fieldType !== DATASET_FIELD_TYPES.BOOLEAN,
-        }),
-        [sourceType, fieldType, controlType, datasetFieldType],
-    );
-
-    const options = getElementOptions(disabledOptions);
 
     return (
         <FormRow label={i18n('field_selector-type')}>

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/helpers/input-type-select.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/helpers/input-type-select.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {Calendar, FontCursor, ListUl, SquareCheck} from '@gravity-ui/icons';
+import {Icon, SelectOption} from '@gravity-ui/uikit';
+import {I18n} from 'i18n';
+
+import {ELEMENT_TYPE} from '../../../../Control/constants';
+
+const i18n = I18n.keyset('dash.control-dialog.edit');
+
+export const getElementOptions = (): SelectOption[] => [
+    {
+        value: ELEMENT_TYPE.SELECT,
+        content: i18n('value_element-select'),
+        data: {
+            icon: <Icon data={ListUl} />,
+        },
+    },
+    {
+        value: ELEMENT_TYPE.INPUT,
+        content: i18n('value_element-input'),
+        data: {
+            icon: <Icon data={FontCursor} />,
+        },
+    },
+    {
+        value: ELEMENT_TYPE.DATE,
+        content: i18n('value_element-date'),
+        data: {
+            icon: <Icon data={Calendar} />,
+        },
+    },
+    {
+        value: ELEMENT_TYPE.CHECKBOX,
+        content: i18n('value_element-checkbox'),
+        data: {
+            icon: <Icon data={SquareCheck} />,
+        },
+    },
+];

--- a/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
@@ -59,7 +59,7 @@ const SelectorTypeSelect = ({size = 'l', showExternalType = true}: SelectorTypeS
             ),
         };
 
-        return CONTROL_SOURCE_TYPES.filter((t) => availabilityMap[t.value]);
+        return CONTROL_SOURCE_TYPES.filter(({value}) => availabilityMap[value]);
     }, [showExternalType]);
 
     return (

--- a/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
@@ -9,11 +9,16 @@ import {setSelectorDialogItem} from 'units/dash/store/actions/dashTyped';
 import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
+const i18nConnectionBasedControlFake = (str: string) => str;
 
 const CONTROL_SOURCE_TYPES = [
     {
         title: i18n('value_source-dataset'),
         value: DashTabItemControlSourceType.Dataset,
+    },
+    {
+        title: i18nConnectionBasedControlFake('value_source-dataset'),
+        value: DashTabItemControlSourceType.Connection,
     },
     {
         title: i18n('value_source-manual'),
@@ -43,15 +48,19 @@ const SelectorTypeSelect = ({size = 'l', showExternalType = true}: SelectorTypeS
         );
     }, []);
 
-    let options;
+    const options = React.useMemo(() => {
+        const availabilityMap = {
+            [DashTabItemControlSourceType.Dataset]: true,
+            [DashTabItemControlSourceType.Manual]: true,
+            [DashTabItemControlSourceType.External]:
+                Utils.isEnabledFeature(Feature.ExternalSelectors) && showExternalType,
+            [DashTabItemControlSourceType.Connection]: Utils.isEnabledFeature(
+                Feature.ConnectionBasedControl,
+            ),
+        };
 
-    if (Utils.isEnabledFeature(Feature.ExternalSelectors) && showExternalType) {
-        options = CONTROL_SOURCE_TYPES;
-    } else {
-        options = CONTROL_SOURCE_TYPES.filter(
-            (item) => item.value !== DashTabItemControlSourceType.External,
-        );
-    }
+        return CONTROL_SOURCE_TYPES.filter((t) => availabilityMap[t.value]);
+    }, [showExternalType]);
 
     return (
         <RadioButton

--- a/src/ui/units/dash/store/actions/controls/types.ts
+++ b/src/ui/units/dash/store/actions/controls/types.ts
@@ -22,7 +22,8 @@ export type SelectorsGroupDialogState = {
 export type SelectorSourceType =
     | DashTabItemControlSourceType.Dataset
     | DashTabItemControlSourceType.Manual
-    | DashTabItemControlSourceType.External;
+    | DashTabItemControlSourceType.External
+    | DashTabItemControlSourceType.Connection;
 
 export type ItemDataSource = {
     chartId?: string;


### PR DESCRIPTION
Related to the [issue](https://github.com/datalens-tech/datalens-ui/issues/653) I've added feature flag (`ConnectionBasedControl`) to hide control while in development process. 

At this point I've added a tab and basic controls that are already used in other tabs. 