### PR TITLE
Replace usage fake i18n to normal i18n for connection based control

### DIFF
--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/AppearanceSection/Rows/InnerTitleRow/InnerTitleRow.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/AppearanceSection/Rows/InnerTitleRow/InnerTitleRow.tsx
@@ -20,12 +20,12 @@ import '../../AppearanceSection.scss';
 const b = block('control2-appearance-section');
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
-const i18nConnectionBasedControlFake = (str: string) => str;
 
 const getHelpPopoverText = (sourceType: SelectorSourceType | undefined): string => {
     switch (sourceType) {
         case DashTabItemControlSourceType.Connection:
-            return i18nConnectionBasedControlFake('field_inner-title-note-connection-selector');
+            // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+            return i18n('field_inner-title-note-connection-selector');
         default:
             return i18n('field_inner-title-note');
     }

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -18,7 +18,6 @@ import {QueryTypeControl} from './components/QueryTypeControl/QueryTypeControl';
 import {getDistinctsByTypedQuery} from './helpers/get-distincts-by-typed-query';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
-const i18nConnectionBasedControlFake = (str: string) => str;
 
 export const ConnectionSettings: React.FC = () => {
     const {connectionQueryTypes, connectionId, connectionQueryContent, connectionQueryType} =
@@ -65,7 +64,8 @@ export const ConnectionSettings: React.FC = () => {
             {connectionQueryTypes?.length && connectionQueryTypes.length > 0 && (
                 <React.Fragment>
                     <ParameterNameInput
-                        label={i18nConnectionBasedControlFake('field_parameter-name')}
+                        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                        label={i18n('field_parameter-name')}
                     />
                     <QueryTypeControl connectionQueryTypes={connectionQueryTypes} />
                     <InputTypeSelector options={options} />

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/ConnectionSelector/ConnectionSelector.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/ConnectionSelector/ConnectionSelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 import {EntryScope} from 'shared';
 import type {GetEntryResponse} from 'shared/schema';
@@ -19,7 +20,7 @@ import {EntrySelector} from '../../../EntrySelector/EntrySelector';
 
 import {prepareConnectionData} from './helpers';
 
-const i18nConnectionBasedControlFake = (str: string) => str;
+const i18n = I18n.keyset('dash.control-dialog.edit');
 const getConnectionLink = (connectionId: string) => `/connections/${connectionId}`;
 export const ConnectionSelector = () => {
     const dispatch = useDispatch();
@@ -86,7 +87,8 @@ export const ConnectionSelector = () => {
 
     return (
         <EntrySelector
-            label={i18nConnectionBasedControlFake('field_connection')}
+            // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+            label={i18n('field_connection')}
             entryId={connectionId}
             scope={EntryScope.Connection}
             handleEntryChange={handleEntryChange}

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/ConnectionSelector/helpers.ts
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/ConnectionSelector/helpers.ts
@@ -1,6 +1,7 @@
+import {I18n} from 'i18n';
 import type {ConnectionData, ConnectionOptions, ConnectionQueryTypeOptions} from 'shared';
 
-const i18nConnectionBasedControlFake = (str: string) => str;
+const i18n = I18n.keyset('dash.control-dialog.edit');
 
 export const prepareConnectionData = (
     connection: ConnectionData,
@@ -9,7 +10,8 @@ export const prepareConnectionData = (
 
     if (!options.allow_typed_query_usage) {
         return {
-            error: i18nConnectionBasedControlFake('error_unsupported-connection'),
+            // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+            error: i18n('error_unsupported-connection'),
             queryTypes: [],
         };
     }
@@ -19,7 +21,8 @@ export const prepareConnectionData = (
     return {
         error: supportedQueryTypes.length
             ? undefined
-            : i18nConnectionBasedControlFake('error_unsupported-connection'),
+            : // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+              i18n('error_unsupported-connection'),
         queryTypes: supportedQueryTypes,
     };
 };

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/QueryTypeControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/QueryTypeControl.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {FormRow} from '@gravity-ui/components';
 import {Select} from '@gravity-ui/uikit';
+import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 import {type ConnectionQueryTypeOptions, ConnectionQueryTypeValues} from 'shared';
 
@@ -11,8 +12,8 @@ import {selectSelectorDialog} from '../../../../../../../../store/selectors/dash
 import {EditLabelControl} from './components/EditLabelControl/EditLabelControl';
 import {EditQueryControl} from './components/EditQueryControl/EditQueryControl';
 import {prepareQueryTypeSelectorOptions} from './helpers';
-
-const i18nConnectionBasedControlFake = (str: string) => str;
+// @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+const i18n = I18n.keyset('dash.edit-query-dialog');
 
 const renderQueryContentControl = (connectionQueryType: ConnectionQueryTypeValues | undefined) => {
     switch (connectionQueryType) {
@@ -57,13 +58,15 @@ export const QueryTypeControl: React.FC<QueryTypeControlProps> = (props: QueryTy
     return (
         <React.Fragment>
             {options.length > 1 && (
-                <FormRow label={i18nConnectionBasedControlFake('field_query-type')}>
+                // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                <FormRow label={i18n('field_query-type')}>
                     <Select
                         width="max"
                         options={options}
                         value={connectionQueryType ? [connectionQueryType] : []}
                         onUpdate={handleQueryTypeUpdate}
-                        placeholder={i18nConnectionBasedControlFake('placeholder_not-defined')}
+                        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                        placeholder={i18n('placeholder_not-defined')}
                     />
                 </FormRow>
             )}

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditLabelControl/EditLabelControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditLabelControl/EditLabelControl.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 
 import {FormRow} from '@gravity-ui/components';
 import {TextInput} from '@gravity-ui/uikit';
+import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {setSelectorDialogItem} from '../../../../../../../../../../store/actions/dashTyped';
 import {selectSelectorDialog} from '../../../../../../../../../../store/selectors/dashTypedSelectors';
-
-const i18nConnectionBasedControlFake = (str: string) => str;
+// @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+const i18n = I18n.keyset('dash.edit-query-dialog');
 export const EditLabelControl = () => {
     const dispatch = useDispatch();
     const {connectionQueryContent} = useSelector(selectSelectorDialog);
@@ -19,7 +20,8 @@ export const EditLabelControl = () => {
     }, []);
 
     return (
-        <FormRow label={i18nConnectionBasedControlFake('field_label')}>
+        //@ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+        <FormRow label={i18n('field_label')}>
             <TextInput value={query} onUpdate={handleQueryChange} />
         </FormRow>
     );

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditQueryControl/EditQueryControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditQueryControl/EditQueryControl.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import {FormRow} from '@gravity-ui/components';
 import {PencilToLine} from '@gravity-ui/icons';
 import {Button, Icon} from '@gravity-ui/uikit';
+import {I18n} from 'i18n';
 import {useDispatch} from 'react-redux';
 
 import {openDialogEditQuery} from '../../../../../../../../../../store/actions/dialogs/dialog-edit-query';
-
-const i18nConnectionBasedControlFake = (str: string) => str;
+// @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+const i18n = I18n.keyset('dash.edit-query-dialog');
 export const EditQueryControl: React.FC = () => {
     const dispatch = useDispatch();
 
@@ -15,10 +16,15 @@ export const EditQueryControl: React.FC = () => {
         dispatch(openDialogEditQuery());
     };
     return (
-        <FormRow label={i18nConnectionBasedControlFake('field_query')}>
+        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+        <FormRow label={i18n('field_query')}>
             <Button view="outlined" onClick={handleButtonClick}>
                 <Icon data={PencilToLine} />
-                {i18nConnectionBasedControlFake('button_edit-query')}
+
+                {
+                    // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                    i18n('button_edit-query')
+                }
             </Button>
         </FormRow>
     );

--- a/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect.tsx
@@ -9,7 +9,6 @@ import {setSelectorDialogItem} from 'units/dash/store/actions/dashTyped';
 import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
-const i18nConnectionBasedControlFake = (str: string) => str;
 
 const CONTROL_SOURCE_TYPES = [
     {
@@ -17,7 +16,8 @@ const CONTROL_SOURCE_TYPES = [
         value: DashTabItemControlSourceType.Dataset,
     },
     {
-        title: i18nConnectionBasedControlFake('value_source-dataset'),
+        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+        title: i18n('value_source-connection'),
         value: DashTabItemControlSourceType.Connection,
     },
     {

--- a/src/ui/units/dash/containers/Dialogs/DialogEditQuery/DialogEditQuery.tsx
+++ b/src/ui/units/dash/containers/Dialogs/DialogEditQuery/DialogEditQuery.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {Dialog, Flex} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
+import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 import type {ConnectionQueryContent} from 'shared';
 import type {GetConnectionTypedQueryErrorResponse} from 'shared/schema';
@@ -25,8 +26,8 @@ export type OpenDialogEditQueryArgs = {
     id: typeof DIALOG_EDIT_QUERY;
     props: undefined;
 };
-
-const i18nConnectionBasedControlFake = (str: string) => str;
+// @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+const i18n = I18n.keyset('dash.edit-query-dialog');
 
 const b = block('dialog-edit-query');
 
@@ -85,7 +86,8 @@ const DialogEditQuery: React.FC = () => {
                 return validation
                     ? handleSuccessResponse(queryContent)
                     : handleWrongQueryRequest(
-                          i18nConnectionBasedControlFake('error_invalid-typed-query-response'),
+                          // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                          i18n('error_invalid-typed-query-response'),
                           query,
                       );
             })
@@ -101,7 +103,8 @@ const DialogEditQuery: React.FC = () => {
     };
     return (
         <Dialog className={b()} open={true} hasCloseButton={true} onClose={handleClose}>
-            <Dialog.Header caption={i18nConnectionBasedControlFake('title_edit-query')} />
+            {/* @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653*/}
+            <Dialog.Header caption={i18n('title_edit-query')} />
             <Dialog.Body>
                 <Flex direction="column" className={b('content')}>
                     <QueryEditor query={query} onQueryEditorUpdate={handleQueryEditorUpdate} />
@@ -118,8 +121,10 @@ const DialogEditQuery: React.FC = () => {
                 propsButtonApply={{disabled}}
                 onClickButtonCancel={handleClose}
                 onClickButtonApply={handleApply}
-                textButtonApply={i18nConnectionBasedControlFake('button_apply')}
-                textButtonCancel={i18nConnectionBasedControlFake('button_cancel')}
+                // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                textButtonApply={i18n('button_apply')}
+                // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                textButtonCancel={i18n('button_cancel')}
             />
         </Dialog>
     );

--- a/src/ui/units/dash/containers/Dialogs/DialogEditQuery/QueryError/QueryError.tsx
+++ b/src/ui/units/dash/containers/Dialogs/DialogEditQuery/QueryError/QueryError.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {I18n} from 'i18n';
+
 import {Collapse} from '../../../../../../components/Collapse/Collapse';
 import {TemplateTextPaper} from '../../../../../../components/TemplateTextPaper/TemplateTextPaper';
 
@@ -8,21 +10,26 @@ export type QueryErrorProps = {
     query: string | undefined;
 };
 
-const i18nConnectionBasedControlFake = (str: string) => str;
+// @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+const i18n = I18n.keyset('dash.edit-query-dialog');
+
 export const QueryError: React.FC<QueryErrorProps> = (props: QueryErrorProps) => {
     const {reason, query} = props;
 
     return (
-        <Collapse title={i18nConnectionBasedControlFake('title_invalid-sql-query')} isExpand={true}>
+        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+        <Collapse title={i18n('title_invalid-sql-query')} isExpand={true}>
             {reason ? (
                 <TemplateTextPaper
-                    title={i18nConnectionBasedControlFake('title_database-response')}
+                    // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                    title={i18n('title_database-response')}
                     content={reason}
                 />
             ) : null}
             {query ? (
                 <TemplateTextPaper
-                    title={i18nConnectionBasedControlFake('title_sent-query')}
+                    // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                    title={i18n('title_sent-query')}
                     content={query}
                 />
             ) : null}


### PR DESCRIPTION
Related to the [issue](https://github.com/datalens-tech/datalens-ui/issues/653). I've added usage of i18n instead fake implementation.

All functionality are hidden behind feature flag `ConnectionBasedControl`