### PR TITLE
Add support parameters for parameters for Control based on connection

### DIFF
--- a/src/server/components/features/features-list/ConnectionBasedControl.ts
+++ b/src/server/components/features/features-list/ConnectionBasedControl.ts
@@ -4,7 +4,7 @@ import {createFeatureConfig} from '../utils';
 export default createFeatureConfig({
     name: Feature.ConnectionBasedControl,
     state: {
-        development: true,
+        development: false,
         production: false,
     },
 });

--- a/src/server/components/features/features-list/ConnectionBasedControl.ts
+++ b/src/server/components/features/features-list/ConnectionBasedControl.ts
@@ -4,7 +4,7 @@ import {createFeatureConfig} from '../utils';
 export default createFeatureConfig({
     name: Feature.ConnectionBasedControl,
     state: {
-        development: false,
+        development: true,
         production: false,
     },
 });

--- a/src/server/modes/charts/plugins/control/js/helpers/process-content.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/process-content.ts
@@ -5,6 +5,7 @@ import type {SourceResponseData} from '../types';
 import {processDatasetSourceTypeContent} from './dataset/process-dataset-content';
 import {processDatasetFields} from './dataset/process-fields';
 import {processTypedQueryContent} from './typed-query/process-typed-query-content';
+import {processTypedQueryParameters} from './typed-query/process-typed-query-parameters';
 
 type ProcessContentArgs = {
     data: SourceResponseData;
@@ -22,6 +23,10 @@ export const processContent = (args: ProcessContentArgs): ControlShared['content
             return processDatasetSourceTypeContent({shared, distincts: data.distincts});
         }
         case DashTabItemControlSourceType.Connection: {
+            processTypedQueryParameters({
+                ChartEditor,
+                parameters: shared.source.selectorParameters,
+            });
             return processTypedQueryContent(data.connectionDistincts);
         }
         default: {

--- a/src/server/modes/charts/plugins/control/js/helpers/process-content.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/process-content.ts
@@ -1,4 +1,9 @@
-import {DashTabItemControlSourceType, type IChartEditor} from '../../../../../../../shared';
+import {
+    DashTabItemControlSourceType,
+    type IChartEditor,
+    type StringParams,
+} from '../../../../../../../shared';
+import {extractTypedQueryParams} from '../../../../../../../shared/modules/typed-query-api/helpers/parameters';
 import type {ControlShared} from '../../types';
 import type {SourceResponseData} from '../types';
 
@@ -11,10 +16,11 @@ type ProcessContentArgs = {
     data: SourceResponseData;
     shared: ControlShared;
     ChartEditor: IChartEditor;
+    params: StringParams;
 };
 export const processContent = (args: ProcessContentArgs): ControlShared['content'] => {
-    const {data, shared, ChartEditor} = args;
-    const {sourceType, source, content} = shared;
+    const {data, shared, ChartEditor, params} = args;
+    const {sourceType, source, content, param} = shared;
 
     switch (sourceType) {
         case DashTabItemControlSourceType.Dataset: {
@@ -25,7 +31,7 @@ export const processContent = (args: ProcessContentArgs): ControlShared['content
         case DashTabItemControlSourceType.Connection: {
             processTypedQueryParameters({
                 ChartEditor,
-                parameters: shared.source.selectorParameters,
+                parameters: extractTypedQueryParams(params, param),
             });
             return processTypedQueryContent(data.connectionDistincts);
         }

--- a/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-content.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-content.ts
@@ -1,4 +1,5 @@
 import type {ConnectionTypedQueryApiResponse} from '../../../../../../../../shared';
+import {getControlDisticntsFromRows} from '../../../../../../../../shared/modules/control/typed-query-helpers';
 import type {ControlShared} from '../../../types';
 
 export const processTypedQueryContent = (
@@ -6,9 +7,5 @@ export const processTypedQueryContent = (
 ): ControlShared['content'] => {
     const rows = distincts?.data?.rows || [];
 
-    return rows.reduce((acc, row) => {
-        const rowData = String(row[0]);
-        acc.push({title: rowData, value: rowData});
-        return acc;
-    }, [] as ControlShared['content']);
+    return getControlDisticntsFromRows(rows).map((v) => ({title: v, value: v}));
 };

--- a/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
@@ -1,0 +1,12 @@
+import type {IChartEditor, StringParams} from '../../../../../../../../shared';
+
+export type ProcessTypedQueryParametersArgs = {
+    parameters?: StringParams;
+    ChartEditor: IChartEditor;
+};
+
+export const processTypedQueryParameters = (args: ProcessTypedQueryParametersArgs) => {
+    const {parameters, ChartEditor} = args;
+
+    ChartEditor.updateParams(parameters || {});
+};

--- a/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
@@ -8,5 +8,10 @@ export type ProcessTypedQueryParametersArgs = {
 export const processTypedQueryParameters = (args: ProcessTypedQueryParametersArgs) => {
     const {parameters, ChartEditor} = args;
 
-    ChartEditor.updateParams(parameters || {});
+    const params = Object.keys(parameters || {}).reduce(
+        (acc, key) => Object.assign(acc, {[key]: ''}),
+        {} as StringParams,
+    );
+
+    ChartEditor.updateParams(params);
 };

--- a/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
+++ b/src/server/modes/charts/plugins/control/js/helpers/typed-query/process-typed-query-parameters.ts
@@ -1,14 +1,14 @@
 import type {IChartEditor, StringParams} from '../../../../../../../../shared';
 
 export type ProcessTypedQueryParametersArgs = {
-    parameters?: StringParams;
+    parameters: StringParams;
     ChartEditor: IChartEditor;
 };
 
 export const processTypedQueryParameters = (args: ProcessTypedQueryParametersArgs) => {
     const {parameters, ChartEditor} = args;
 
-    const params = Object.keys(parameters || {}).reduce(
+    const params = Object.keys(parameters).reduce(
         (acc, key) => Object.assign(acc, {[key]: ''}),
         {} as StringParams,
     );

--- a/src/server/modes/charts/plugins/control/js/index.ts
+++ b/src/server/modes/charts/plugins/control/js/index.ts
@@ -17,7 +17,7 @@ export default ({
     params: Record<string, string | string[]>;
     ChartEditor: IChartEditor;
 }) => {
-    shared.content = processContent({data, shared, ChartEditor});
+    shared.content = processContent({data, shared, ChartEditor, params});
 
     const {source, param, content} = shared;
 

--- a/src/server/modes/charts/plugins/control/types.ts
+++ b/src/server/modes/charts/plugins/control/types.ts
@@ -4,7 +4,6 @@ import {
     DashTabItemControlElementType,
     DashTabItemControlSourceType,
     DatasetFieldType,
-    type StringParams,
 } from '../../../../../shared';
 
 export type ControlShared = {
@@ -31,7 +30,6 @@ export type ControlShared = {
         defaultValue: any;
         required?: boolean;
         connectionId?: string;
-        selectorParameters?: StringParams;
         connectionQueryType?: ConnectionQueryTypeValues;
         connectionQueryContent?: ConnectionQueryContent;
     };

--- a/src/server/modes/charts/plugins/control/types.ts
+++ b/src/server/modes/charts/plugins/control/types.ts
@@ -4,6 +4,7 @@ import {
     DashTabItemControlElementType,
     DashTabItemControlSourceType,
     DatasetFieldType,
+    type StringParams,
 } from '../../../../../shared';
 
 export type ControlShared = {
@@ -30,6 +31,7 @@ export type ControlShared = {
         defaultValue: any;
         required?: boolean;
         connectionId?: string;
+        selectorParameters?: StringParams;
         connectionQueryType?: ConnectionQueryTypeValues;
         connectionQueryContent?: ConnectionQueryContent;
     };

--- a/src/server/modes/charts/plugins/control/url/typed-query/index.ts
+++ b/src/server/modes/charts/plugins/control/url/typed-query/index.ts
@@ -1,4 +1,4 @@
-import {mapStringParameterToTypedQueryApiParameter} from '../../../../../../../shared/modules/typed-query-api';
+import {mapParametersRecordToTypedQueryApiParameters} from '../../../../../../../shared/modules/typed-query-api';
 import {CONNECTIONS_TYPED_QUERY_URL, CONNECTION_ID_PLACEHOLDER} from '../constants';
 import type {SourceControlArgs, SourceControlTypedQueryRequest} from '../types';
 
@@ -14,9 +14,7 @@ export const prepareTypedQueryRequest = (
         throw new Error('Missed required fields for TypedQueryApi request');
     }
 
-    const parameters = Object.entries(params).map(([key, value]) =>
-        mapStringParameterToTypedQueryApiParameter(key, value),
-    );
+    const parameters = mapParametersRecordToTypedQueryApiParameters(params);
 
     return {
         url: CONNECTIONS_TYPED_QUERY_URL.replace(CONNECTION_ID_PLACEHOLDER, connectionId),

--- a/src/shared/modules/typed-query-api/helpers/parameters.ts
+++ b/src/shared/modules/typed-query-api/helpers/parameters.ts
@@ -1,0 +1,10 @@
+import {omit} from 'lodash';
+
+import type {StringParams} from '../../../types';
+
+export const extractTypedQueryParams = (
+    params: StringParams | undefined,
+    fieldName: string | undefined,
+): StringParams => {
+    return omit(params ?? {}, fieldName ?? '');
+};

--- a/src/ui/components/SectionWrapper/SectionWrapper.tsx
+++ b/src/ui/components/SectionWrapper/SectionWrapper.tsx
@@ -3,21 +3,26 @@ import React from 'react';
 import block from 'bem-cn-lite';
 import {Collapse} from 'components/Collapse/Collapse';
 
+import type {CollapseProps} from '../Collapse/types';
+
 import './SectionWrapper.scss';
 
 const b = block('section-wrapper');
 
 export type SectionWrapperProps = {
     className?: string;
-    title?: string;
+    title?: string | JSX.Element;
     titleMods?: string;
     subTitle?: string;
     withCollapse?: boolean;
     isStylesHidden?: boolean;
+    arrowPosition?: CollapseProps['arrowPosition'];
+    arrowQa?: CollapseProps['arrowQa'];
+    defaultIsExpanded?: boolean;
 };
 
 type SectionBodyProps = {
-    title?: string;
+    title?: string | JSX.Element;
     subTitle?: string;
     className?: string;
     titleModsVal: Record<string, boolean> | null;
@@ -51,7 +56,13 @@ const SectionWrapper: React.FC<SectionWrapperProps> = (props) => {
                 className={props.className}
                 isStylesHidden={props.isStylesHidden}
             >
-                <Collapse defaultIsExpand={true} title={props.title || ''} titleSize="m">
+                <Collapse
+                    defaultIsExpand={props.defaultIsExpanded ?? true}
+                    arrowPosition={props.arrowPosition}
+                    arrowQa={props.arrowQa}
+                    title={props.title || ''}
+                    titleSize="m"
+                >
                     {props.children}
                 </Collapse>
             </SectionBody>

--- a/src/ui/units/dash/containers/Dialogs/Control2/Control2.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Control2.tsx
@@ -12,7 +12,10 @@ import {CommonSettingsSection} from 'units/dash/containers/Dialogs/Control2/Sect
 import {SelectorPreview} from 'units/dash/containers/Dialogs/Control2/SelectorPreview/SelectorPreview';
 import {SelectorTypeSelect} from 'units/dash/containers/Dialogs/Control2/SelectorTypeSelect/SelectorTypeSelect';
 import {applyControl2Dialog, closeControl2Dialog} from 'units/dash/store/actions/dashTyped';
-import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
+import {
+    selectIsParametersSectionAvailable,
+    selectSelectorDialog,
+} from 'units/dash/store/selectors/dashTypedSelectors';
 
 import {ParametersSection} from './Sections/ParametersSection/ParametersSection';
 
@@ -61,7 +64,7 @@ class DialogAddControl extends React.Component<Props> {
         const {sourceType, isEdit} = this.props;
         const showTypeSelect =
             !isEdit || !Utils.isEnabledFeature(Feature.GroupControls) || sourceType !== 'external';
-        const showParametersSection = this.isParametersSectionAvailable();
+        const showParametersSection = this.props.isParametersSectionAvailable;
 
         return (
             <div>
@@ -107,23 +110,13 @@ class DialogAddControl extends React.Component<Props> {
     private handleApply = () => {
         this.props.actions.applyControl2Dialog();
     };
-
-    private isParametersSectionAvailable = () => {
-        const {sourceType} = this.props;
-
-        switch (sourceType) {
-            case DashTabItemControlSourceType.Connection:
-                return true;
-            default:
-                return false;
-        }
-    };
 }
 
 const mapStateToProps = (state: DatalensGlobalState) => {
     return {
         isEdit: Boolean(state.dash.openedItemId),
         sourceType: selectSelectorDialog(state).sourceType,
+        isParametersSectionAvailable: selectIsParametersSectionAvailable(state),
     };
 };
 

--- a/src/ui/units/dash/containers/Dialogs/Control2/Control2.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Control2.tsx
@@ -14,6 +14,8 @@ import {SelectorTypeSelect} from 'units/dash/containers/Dialogs/Control2/Selecto
 import {applyControl2Dialog, closeControl2Dialog} from 'units/dash/store/actions/dashTyped';
 import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
 
+import {ParametersSection} from './Sections/ParametersSection/ParametersSection';
+
 import './Control2.scss';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
@@ -59,6 +61,7 @@ class DialogAddControl extends React.Component<Props> {
         const {sourceType, isEdit} = this.props;
         const showTypeSelect =
             !isEdit || !Utils.isEnabledFeature(Feature.GroupControls) || sourceType !== 'external';
+        const showParametersSection = this.isParametersSectionAvailable();
 
         return (
             <div>
@@ -73,6 +76,11 @@ class DialogAddControl extends React.Component<Props> {
                 <div className={b('section')}>
                     <CommonSettingsSection />
                 </div>
+                {showParametersSection && (
+                    <div className={b('section')}>
+                        <ParametersSection />
+                    </div>
+                )}
                 {this.renderAppearanceSection()}
             </div>
         );
@@ -98,6 +106,17 @@ class DialogAddControl extends React.Component<Props> {
 
     private handleApply = () => {
         this.props.actions.applyControl2Dialog();
+    };
+
+    private isParametersSectionAvailable = () => {
+        const {sourceType} = this.props;
+
+        switch (sourceType) {
+            case DashTabItemControlSourceType.Connection:
+                return true;
+            default:
+                return false;
+        }
     };
 }
 

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -20,8 +20,13 @@ import {getDistinctsByTypedQuery} from './helpers/get-distincts-by-typed-query';
 const i18n = I18n.keyset('dash.control-dialog.edit');
 
 export const ConnectionSettings: React.FC = () => {
-    const {connectionQueryTypes, connectionId, connectionQueryContent, connectionQueryType} =
-        useSelector(selectSelectorDialog);
+    const {
+        connectionQueryTypes,
+        connectionId,
+        connectionQueryContent,
+        connectionQueryType,
+        selectorParameters,
+    } = useSelector(selectSelectorDialog);
     const workbookId = useSelector(selectWorkbookId);
 
     const options = React.useMemo(() => {
@@ -39,7 +44,7 @@ export const ConnectionSettings: React.FC = () => {
                 connectionId,
                 connectionQueryContent,
                 connectionQueryType,
-                parameters: {},
+                parameters: selectorParameters || {},
             }),
         [connectionId, connectionQueryContent, connectionQueryType, workbookId],
     );

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/ConnectionSettings.tsx
@@ -66,7 +66,7 @@ export const ConnectionSettings: React.FC = () => {
     return (
         <SectionWrapper title={i18n('label_common-settings')}>
             <ConnectionSelector />
-            {connectionQueryTypes?.length && connectionQueryTypes.length > 0 && (
+            {connectionQueryTypes && connectionQueryTypes.length > 0 && (
                 <React.Fragment>
                     <ParameterNameInput
                         // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/QueryTypeControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/QueryTypeControl.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 
 import {FormRow} from '@gravity-ui/components';
+import type {StringParams} from '@gravity-ui/dashkit';
 import {Select} from '@gravity-ui/uikit';
 import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
-import {type ConnectionQueryTypeOptions, ConnectionQueryTypeValues} from 'shared';
+import {
+    type ConnectionQueryTypeOptions,
+    ConnectionQueryTypeValues,
+    type ConnectionRequiredParameter,
+} from 'shared';
 
 import {setSelectorDialogItem} from '../../../../../../../../store/actions/dashTyped';
 import {selectSelectorDialog} from '../../../../../../../../store/selectors/dashTypedSelectors';
@@ -30,6 +35,9 @@ type QueryTypeControlProps = {
     connectionQueryTypes: ConnectionQueryTypeOptions[];
 };
 
+const prepareRequiredParameters = (params: ConnectionRequiredParameter[]): StringParams =>
+    params.reduce((acc, param) => Object.assign(acc, {[param.name]: ''}), {} as StringParams);
+
 export const QueryTypeControl: React.FC<QueryTypeControlProps> = (props: QueryTypeControlProps) => {
     const dispatch = useDispatch();
 
@@ -39,8 +47,12 @@ export const QueryTypeControl: React.FC<QueryTypeControlProps> = (props: QueryTy
 
     React.useEffect(() => {
         if (!connectionQueryType && connectionQueryTypes.length === 1) {
+            const {query_type, required_parameters} = connectionQueryTypes[0];
             dispatch(
-                setSelectorDialogItem({connectionQueryType: connectionQueryTypes[0].query_type}),
+                setSelectorDialogItem({
+                    connectionQueryType: query_type,
+                    selectorParameters: prepareRequiredParameters(required_parameters),
+                }),
             );
         }
     }, [connectionId]);
@@ -50,7 +62,21 @@ export const QueryTypeControl: React.FC<QueryTypeControlProps> = (props: QueryTy
     const handleQueryTypeUpdate = React.useCallback(
         (selected: string[]) => {
             const value = selected[0] as ConnectionQueryTypeValues;
-            dispatch(setSelectorDialogItem({connectionQueryType: value}));
+
+            const selectedQueryType = connectionQueryTypes.find((f) => f.query_type === value);
+
+            if (!selectedQueryType) {
+                throw new Error(`Unsupported query type value selected, ${value}`);
+            }
+
+            const {query_type, required_parameters} = selectedQueryType;
+
+            dispatch(
+                setSelectorDialogItem({
+                    connectionQueryType: query_type,
+                    selectorParameters: prepareRequiredParameters(required_parameters),
+                }),
+            );
         },
         [dispatch],
     );

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditLabelControl/EditLabelControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditLabelControl/EditLabelControl.tsx
@@ -5,13 +5,14 @@ import {TextInput} from '@gravity-ui/uikit';
 import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 
+import {FieldWrapper} from '../../../../../../../../../../../../components/FieldWrapper/FieldWrapper';
 import {setSelectorDialogItem} from '../../../../../../../../../../store/actions/dashTyped';
 import {selectSelectorDialog} from '../../../../../../../../../../store/selectors/dashTypedSelectors';
 // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
 const i18n = I18n.keyset('dash.edit-query-dialog');
 export const EditLabelControl = () => {
     const dispatch = useDispatch();
-    const {connectionQueryContent} = useSelector(selectSelectorDialog);
+    const {connectionQueryContent, validation} = useSelector(selectSelectorDialog);
 
     const query = connectionQueryContent?.query ?? '';
 
@@ -22,7 +23,9 @@ export const EditLabelControl = () => {
     return (
         //@ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
         <FormRow label={i18n('field_label')}>
-            <TextInput value={query} onUpdate={handleQueryChange} />
+            <FieldWrapper error={validation.connectionQueryContent}>
+                <TextInput value={query} onUpdate={handleQueryChange} />
+            </FieldWrapper>
         </FormRow>
     );
 };

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditQueryControl/EditQueryControl.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/components/QueryTypeControl/components/EditQueryControl/EditQueryControl.tsx
@@ -4,12 +4,15 @@ import {FormRow} from '@gravity-ui/components';
 import {PencilToLine} from '@gravity-ui/icons';
 import {Button, Icon} from '@gravity-ui/uikit';
 import {I18n} from 'i18n';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 
+import {FieldWrapper} from '../../../../../../../../../../../../components/FieldWrapper/FieldWrapper';
 import {openDialogEditQuery} from '../../../../../../../../../../store/actions/dialogs/dialog-edit-query';
+import {selectSelectorDialog} from '../../../../../../../../../../store/selectors/dashTypedSelectors';
 // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
 const i18n = I18n.keyset('dash.edit-query-dialog');
 export const EditQueryControl: React.FC = () => {
+    const {validation} = useSelector(selectSelectorDialog);
     const dispatch = useDispatch();
 
     const handleButtonClick = () => {
@@ -18,14 +21,19 @@ export const EditQueryControl: React.FC = () => {
     return (
         // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
         <FormRow label={i18n('field_query')}>
-            <Button view="outlined" onClick={handleButtonClick}>
-                <Icon data={PencilToLine} />
+            <FieldWrapper error={validation.connectionQueryContent}>
+                <Button
+                    view={validation.connectionQueryContent ? 'outlined-danger' : 'outlined'}
+                    onClick={handleButtonClick}
+                >
+                    <Icon data={PencilToLine} />
 
-                {
-                    // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
-                    i18n('button_edit-query')
-                }
-            </Button>
+                    {
+                        // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+                        i18n('button_edit-query')
+                    }
+                </Button>
+            </FieldWrapper>
         </FormRow>
     );
 };

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/helpers/get-distincts-by-typed-query.ts
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ConnectionSettings/helpers/get-distincts-by-typed-query.ts
@@ -1,6 +1,7 @@
 import type {SelectOption} from '@gravity-ui/uikit';
 import {type ConnectionQueryContent, ConnectionQueryTypeValues, type WorkbookId} from 'shared';
 import {getControlDisticntsFromRows} from 'shared/modules/control/typed-query-helpers';
+import {mapParametersRecordToTypedQueryApiParameters} from 'shared/modules/typed-query-api';
 
 import type {PaginationResponse} from '../../../../../../../../../components/Select/hooks/useSelectInfinityFetch/types';
 import logger from '../../../../../../../../../libs/logger';
@@ -16,7 +17,8 @@ type GetConnectionDistinctsArgs = {
 export const getDistinctsByTypedQuery = async (
     args: GetConnectionDistinctsArgs,
 ): Promise<PaginationResponse<SelectOption[], any>> => {
-    const {connectionId, workbookId, connectionQueryType, connectionQueryContent} = args;
+    const {connectionId, workbookId, connectionQueryType, connectionQueryContent, parameters} =
+        args;
 
     if (!connectionId || !connectionQueryType || !connectionQueryContent) {
         return {response: undefined};
@@ -28,7 +30,7 @@ export const getDistinctsByTypedQuery = async (
             workbookId,
             body: {
                 query_content: connectionQueryContent,
-                parameters: [],
+                parameters: mapParametersRecordToTypedQueryApiParameters(parameters),
                 query_type: connectionQueryType,
             },
         });

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ExternalSelectorSettings/ExternalSelectorSettings.scss
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ExternalSelectorSettings/ExternalSelectorSettings.scss
@@ -9,19 +9,6 @@
         margin-left: -60px;
     }
 
-    &__params-title {
-        @include text-subheader-2();
-        font-weight: 500;
-    }
-
-    &__params {
-        margin-top: 12px;
-    }
-
-    &__params-tag {
-        max-width: 160px;
-    }
-
     &__link {
         grid-auto-rows: 40px;
         --dl-dropdown-navigation-width: initial;

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ExternalSelectorSettings/ExternalSelectorSettings.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/CommonSettingsSection/ExternalSelectorSettings/ExternalSelectorSettings.tsx
@@ -7,22 +7,13 @@ import {FieldWrapper} from 'components/FieldWrapper/FieldWrapper';
 import {i18n} from 'i18n';
 import update, {Context, CustomCommands, Spec} from 'immutability-helper';
 import {useDispatch, useSelector} from 'react-redux';
-import {ControlQA, ParamsSettingsQA, StringParams} from 'shared';
+import {ControlQA, StringParams} from 'shared';
 import NavigationInput from 'units/dash/components/NavigationInput/NavigationInput';
 import {ENTRY_TYPE} from 'units/dash/modules/constants';
 import {setSelectorDialogItem} from 'units/dash/store/actions/dashTyped';
 import {selectSelectorDialog} from 'units/dash/store/selectors/dashTypedSelectors';
 
-import {Collapse} from '../../../../../../../../components/Collapse/Collapse';
 import {SectionWrapper} from '../../../../../../../../components/SectionWrapper/SectionWrapper';
-import {ParamsSettings} from '../../../../../../../../units/dash/components/ParamsSettings/ParamsSettings';
-import {
-    clearEmptyParams,
-    removeParam,
-    updateParamTitle,
-    updateParamValue,
-    validateParamTitleOnlyUnderscore,
-} from '../../../../../../../../units/dash/components/ParamsSettings/helpers';
 
 import './ExternalSelectorSettings.scss';
 
@@ -38,9 +29,12 @@ imm.extend('$auto', (value, object) => {
 
 const ExternalSelectorSettings = () => {
     const dispatch = useDispatch();
-    const {autoHeight, chartId, title, defaults, validation} = useSelector(selectSelectorDialog);
-    const localParams = React.useMemo(() => clearEmptyParams(defaults), [defaults]);
-    const [externalChangedId, setExternalChangedId] = React.useState(0);
+    const {autoHeight, chartId, title, selectorParameters, validation, selectorParametersGroup} =
+        useSelector(selectSelectorDialog);
+
+    React.useEffect(() => {
+        dispatch(setSelectorDialogItem({selectorParametersGroup: 0}));
+    }, []);
 
     const handleAutoHeightUpdate = React.useCallback((value: boolean) => {
         dispatch(
@@ -54,21 +48,28 @@ const ExternalSelectorSettings = () => {
         (value: {entryId: string; name: string; params?: StringParams}) => {
             const parsedParams = value.params || {};
 
-            const {defaults: mergedDefaults} = imm.update<
-                {defaults: StringParams},
+            const {selectorParameters: mergedSelectorParameters} = imm.update<
+                {selectorParameters: StringParams},
                 AutoExtendCommand<StringParams>
-            >({defaults}, {defaults: {$auto: {$merge: parsedParams}}});
+            >(
+                {selectorParameters: selectorParameters || {}},
+                {selectorParameters: {$auto: {$merge: parsedParams}}},
+            );
 
             dispatch(
                 setSelectorDialogItem({
                     chartId: value.entryId,
                     title: title || value.name,
-                    defaults: mergedDefaults,
+                    selectorParameters: mergedSelectorParameters,
                 }),
             );
-            setExternalChangedId(externalChangedId + 1);
+            dispatch(
+                setSelectorDialogItem({
+                    selectorParametersGroup: (selectorParametersGroup ?? 0) + 1,
+                }),
+            );
         },
-        [title, defaults, externalChangedId],
+        [selectorParameters, dispatch, title, selectorParametersGroup],
     );
 
     const handleTitleUpdate = React.useCallback((newTitle: string) => {
@@ -77,57 +78,6 @@ const ExternalSelectorSettings = () => {
                 title: newTitle,
             }),
         );
-    }, []);
-
-    const handleEditParamTitle = React.useCallback(
-        (paramTitleOld, paramTitle) => {
-            dispatch(
-                setSelectorDialogItem({
-                    defaults: updateParamTitle(localParams, paramTitleOld, paramTitle),
-                }),
-            );
-        },
-        [localParams],
-    );
-
-    const handleEditParamValue = React.useCallback(
-        (paramTitle, paramValue) => {
-            dispatch(
-                setSelectorDialogItem({
-                    defaults: updateParamValue(localParams, paramTitle, paramValue),
-                }),
-            );
-        },
-        [localParams],
-    );
-
-    const handleRemoveParam = React.useCallback(
-        (paramTitle) => {
-            dispatch(
-                setSelectorDialogItem({
-                    defaults: removeParam(localParams, paramTitle),
-                }),
-            );
-        },
-        [localParams],
-    );
-
-    const handleRemoveAllParams = React.useCallback(() => {
-        dispatch(
-            setSelectorDialogItem({
-                defaults: {},
-            }),
-        );
-    }, []);
-
-    const handleValidateParamTitle = React.useCallback((paramTitle: string) => {
-        const errorCode = validateParamTitleOnlyUnderscore(paramTitle);
-
-        if (errorCode) {
-            return new Error(i18n('dash.params-button-dialog.view', `context_${errorCode}`));
-        }
-
-        return null;
     }, []);
 
     return (
@@ -166,31 +116,6 @@ const ExternalSelectorSettings = () => {
                         size="l"
                     />
                 </FormRow>
-            </SectionWrapper>
-
-            <SectionWrapper className={b()}>
-                <Collapse
-                    title={
-                        <div className={b('params-title')}>
-                            {i18n('dash.control-dialog.edit', 'field_params')}
-                        </div>
-                    }
-                    arrowPosition="left"
-                    arrowQa={ParamsSettingsQA.Open}
-                >
-                    <div className={b('params')}>
-                        <ParamsSettings
-                            group={externalChangedId}
-                            tagLabelClassName={b('params-tag')}
-                            data={defaults}
-                            validator={{title: handleValidateParamTitle}}
-                            onEditParamTitle={handleEditParamTitle}
-                            onEditParamValue={handleEditParamValue}
-                            onRemoveParam={handleRemoveParam}
-                            onRemoveAllParams={handleRemoveAllParams}
-                        />
-                    </div>
-                </Collapse>
             </SectionWrapper>
         </React.Fragment>
     );

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.scss
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.scss
@@ -1,3 +1,5 @@
+@import '~@gravity-ui/uikit/styles/mixins';
+
 .parameters-section {
     margin-top: 12px;
 

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.scss
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.scss
@@ -1,0 +1,11 @@
+.parameters-section {
+    margin-top: 12px;
+
+    &__title {
+        @include text-subheader-2();
+        font-weight: 500;
+    }
+    &__tag {
+        max-width: 160px;
+    }
+}

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import {I18n} from 'i18n';
+
+import {SectionWrapper} from '../../../../../../../components/SectionWrapper/SectionWrapper';
+
+const i18n = I18n.keyset('dash.control-dialog.edit');
+
+export const ParametersSection = () => {
+    return <SectionWrapper withCollapse={true} title={i18n('field_params')}></SectionWrapper>;
+};

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
@@ -1,11 +1,74 @@
 import React from 'react';
 
 import {I18n} from 'i18n';
+import {useDispatch, useSelector} from 'react-redux';
 
 import {SectionWrapper} from '../../../../../../../components/SectionWrapper/SectionWrapper';
+import {ParamsSettings} from '../../../../../components/ParamsSettings/ParamsSettings';
+import {
+    removeParam,
+    updateParamTitle,
+    updateParamValue,
+} from '../../../../../components/ParamsSettings/helpers';
+import {setSelectorDialogItem} from '../../../../../store/actions/dashTyped';
+import {selectSelectorDialog} from '../../../../../store/selectors/dashTypedSelectors';
 
 const i18n = I18n.keyset('dash.control-dialog.edit');
 
 export const ParametersSection = () => {
-    return <SectionWrapper withCollapse={true} title={i18n('field_params')}></SectionWrapper>;
+    const dispatch = useDispatch();
+    const {selectorParameters = {}} = useSelector(selectSelectorDialog);
+
+    const handleParamTitleUpdate = React.useCallback(
+        (old: string, updated: string) => {
+            dispatch(
+                setSelectorDialogItem({
+                    selectorParameters: updateParamTitle(selectorParameters, old, updated),
+                }),
+            );
+        },
+        [dispatch, selectorParameters],
+    );
+
+    const handleParamValueUpdate = React.useCallback(
+        (title: string, value: string[]) => {
+            dispatch(
+                setSelectorDialogItem({
+                    selectorParameters: updateParamValue(selectorParameters, title, value),
+                }),
+            );
+        },
+        [dispatch, selectorParameters],
+    );
+
+    const handleRemoveParam = React.useCallback(
+        (title: string) => {
+            dispatch(
+                setSelectorDialogItem({
+                    selectorParameters: removeParam(selectorParameters, title),
+                }),
+            );
+        },
+        [dispatch, selectorParameters],
+    );
+
+    const handleRemoveAllParams = React.useCallback(() => {
+        dispatch(
+            setSelectorDialogItem({
+                selectorParameters: {},
+            }),
+        );
+    }, []);
+
+    return (
+        <SectionWrapper withCollapse={true} title={i18n('field_params')}>
+            <ParamsSettings
+                data={selectorParameters}
+                onEditParamTitle={handleParamTitleUpdate}
+                onEditParamValue={handleParamValueUpdate}
+                onRemoveParam={handleRemoveParam}
+                onRemoveAllParams={handleRemoveAllParams}
+            />
+        </SectionWrapper>
+    );
 };

--- a/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Control2/Sections/ParametersSection/ParametersSection.tsx
@@ -17,6 +17,8 @@ import {
 import {setSelectorDialogItem} from '../../../../../store/actions/dashTyped';
 import {selectSelectorDialog} from '../../../../../store/selectors/dashTypedSelectors';
 
+import './ParametersSection.scss';
+
 const b = block('parameters-section');
 
 export const ParametersSection = () => {

--- a/src/ui/units/dash/containers/Dialogs/DialogEditQuery/DialogEditQuery.tsx
+++ b/src/ui/units/dash/containers/Dialogs/DialogEditQuery/DialogEditQuery.tsx
@@ -5,6 +5,7 @@ import block from 'bem-cn-lite';
 import {I18n} from 'i18n';
 import {useDispatch, useSelector} from 'react-redux';
 import type {ConnectionQueryContent} from 'shared';
+import {mapParametersRecordToTypedQueryApiParameters} from 'shared/modules/typed-query-api';
 import type {GetConnectionTypedQueryErrorResponse} from 'shared/schema';
 
 import DialogManager from '../../../../../components/DialogManager/DialogManager';
@@ -33,7 +34,7 @@ const b = block('dialog-edit-query');
 
 const DialogEditQuery: React.FC = () => {
     const dispatch = useDispatch();
-    const {connectionQueryContent, connectionQueryType, connectionId} =
+    const {connectionQueryContent, connectionQueryType, connectionId, selectorParameters} =
         useSelector(selectSelectorDialog);
     const workbookId = useSelector(selectWorkbookId);
 
@@ -77,7 +78,9 @@ const DialogEditQuery: React.FC = () => {
                 body: {
                     query_type: connectionQueryType,
                     query_content: queryContent,
-                    parameters: [],
+                    parameters: mapParametersRecordToTypedQueryApiParameters(
+                        selectorParameters || {},
+                    ),
                 },
             })
             .then((response) => {

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -41,7 +41,8 @@ export const getControlDefaultsForField = (
     defaults: Record<string, string | string[]>,
     selectorDialog: SelectorDialogState,
 ) => {
-    const {sourceType, datasetFieldId, fieldName, defaultValue} = selectorDialog;
+    const {sourceType, datasetFieldId, fieldName, defaultValue, selectorParameters} =
+        selectorDialog;
 
     let field;
     switch (sourceType) {
@@ -58,6 +59,7 @@ export const getControlDefaultsForField = (
 
     if (field) {
         return {
+            ...selectorParameters,
             [field]: addOperationForValue({
                 operation: selectorDialog.operation,
                 value: defaultValue || '',

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -113,7 +113,6 @@ export const getItemDataSource = (selectorDialog: SelectorDialogState): ItemData
         connectionQueryContent,
         connectionId,
         connectionQueryType,
-        selectorParameters,
     } = selectorDialog;
 
     if (sourceType === DashTabItemControlSourceType.External) {
@@ -154,7 +153,6 @@ export const getItemDataSource = (selectorDialog: SelectorDialogState): ItemData
                 connectionId,
                 connectionQueryType,
                 connectionQueryContent,
-                selectorParameters,
             };
     }
 

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -113,6 +113,7 @@ export const getItemDataSource = (selectorDialog: SelectorDialogState): ItemData
         connectionQueryContent,
         connectionId,
         connectionQueryType,
+        selectorParameters,
     } = selectorDialog;
 
     if (sourceType === DashTabItemControlSourceType.External) {
@@ -153,6 +154,7 @@ export const getItemDataSource = (selectorDialog: SelectorDialogState): ItemData
                 connectionId,
                 connectionQueryType,
                 connectionQueryContent,
+                selectorParameters,
             };
     }
 

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -14,7 +14,15 @@ const fieldNameValidationSourceTypes: Partial<Record<DashTabItemControlSourceTyp
 };
 
 export const getControlValidation = (selectorDialog: SelectorDialogState) => {
-    const {title, sourceType, datasetFieldId, fieldName, defaultValue, required} = selectorDialog;
+    const {
+        title,
+        sourceType,
+        datasetFieldId,
+        fieldName,
+        defaultValue,
+        required,
+        connectionQueryContent,
+    } = selectorDialog;
 
     const validation: SelectorDialogValidation = {};
 
@@ -24,6 +32,10 @@ export const getControlValidation = (selectorDialog: SelectorDialogState) => {
 
     if (sourceType && fieldNameValidationSourceTypes[sourceType] && !fieldName) {
         validation.fieldName = i18n('dash.control-dialog.edit', 'validation_required');
+    }
+
+    if (sourceType === DashTabItemControlSourceType.Connection && !connectionQueryContent) {
+        validation.connectionQueryContent = i18n('dash.control-dialog.edit', 'validation_required');
     }
 
     if (sourceType === DashTabItemControlSourceType.Dataset && !datasetFieldId) {

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -83,7 +83,7 @@ export const getControlDefaultsForField = (
 
     return Object.keys(merged).reduce<Record<string, string | string[]>>((params, paramTitle) => {
         if (validateParamTitleOnlyUnderscore(paramTitle) === null) {
-            params[paramTitle] = defaults[paramTitle];
+            params[paramTitle] = merged[paramTitle];
         }
         return params;
     }, {});

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -79,7 +79,9 @@ export const getControlDefaultsForField = (
         };
     }
 
-    return Object.keys(defaults).reduce<Record<string, string | string[]>>((params, paramTitle) => {
+    const merged = Object.assign({}, defaults, selectorParameters);
+
+    return Object.keys(merged).reduce<Record<string, string | string[]>>((params, paramTitle) => {
         if (validateParamTitleOnlyUnderscore(paramTitle) === null) {
             params[paramTitle] = defaults[paramTitle];
         }

--- a/src/ui/units/dash/store/actions/controls/helpers.ts
+++ b/src/ui/units/dash/store/actions/controls/helpers.ts
@@ -22,6 +22,7 @@ export const getControlValidation = (selectorDialog: SelectorDialogState) => {
         defaultValue,
         required,
         connectionQueryContent,
+        selectorParameters,
     } = selectorDialog;
 
     const validation: SelectorDialogValidation = {};
@@ -36,6 +37,18 @@ export const getControlValidation = (selectorDialog: SelectorDialogState) => {
 
     if (sourceType === DashTabItemControlSourceType.Connection && !connectionQueryContent) {
         validation.connectionQueryContent = i18n('dash.control-dialog.edit', 'validation_required');
+    }
+
+    if (
+        sourceType === DashTabItemControlSourceType.Connection &&
+        fieldName &&
+        Object.hasOwnProperty.call(selectorParameters, fieldName)
+    ) {
+        validation.fieldName = i18n(
+            'dash.control-dialog.edit',
+            // @ts-ignore TODO add keysets before close https://github.com/datalens-tech/datalens-ui/issues/653
+            'validation_field-name-in-parameters',
+        );
     }
 
     if (sourceType === DashTabItemControlSourceType.Dataset && !datasetFieldId) {

--- a/src/ui/units/dash/store/actions/controls/types.ts
+++ b/src/ui/units/dash/store/actions/controls/types.ts
@@ -1,4 +1,4 @@
-import {ConnectionQueryTypeValues, type StringParams} from 'shared';
+import {ConnectionQueryTypeValues} from 'shared';
 import type {Operations} from 'shared/modules';
 import {
     type ConnectionQueryContent,
@@ -52,5 +52,4 @@ export type ItemDataSource = {
     connectionId?: string;
     connectionQueryType?: ConnectionQueryTypeValues;
     connectionQueryContent?: ConnectionQueryContent;
-    selectorParameters?: StringParams;
 };

--- a/src/ui/units/dash/store/actions/controls/types.ts
+++ b/src/ui/units/dash/store/actions/controls/types.ts
@@ -1,4 +1,4 @@
-import {ConnectionQueryTypeValues} from 'shared';
+import {ConnectionQueryTypeValues, type StringParams} from 'shared';
 import type {Operations} from 'shared/modules';
 import {
     type ConnectionQueryContent,
@@ -52,4 +52,5 @@ export type ItemDataSource = {
     connectionId?: string;
     connectionQueryType?: ConnectionQueryTypeValues;
     connectionQueryContent?: ConnectionQueryContent;
+    selectorParameters?: StringParams;
 };

--- a/src/ui/units/dash/store/actions/controls/types.ts
+++ b/src/ui/units/dash/store/actions/controls/types.ts
@@ -14,6 +14,7 @@ export type SelectorDialogValidation = {
     fieldName?: string;
     datasetFieldId?: string;
     defaultValue?: string;
+    connectionQueryContent?: string;
 };
 
 export type SelectorsGroupDialogState = {

--- a/src/ui/units/dash/store/actions/dashTyped.ts
+++ b/src/ui/units/dash/store/actions/dashTyped.ts
@@ -375,6 +375,7 @@ export type SelectorDialogState = {
     datasetId?: string;
     connectionId?: string;
     selectorParameters?: StringParams;
+    selectorParametersGroup?: number;
     connectionQueryType?: ConnectionQueryTypeValues;
     connectionQueryTypes?: ConnectionQueryTypeOptions[];
     connectionQueryContent?: ConnectionQueryContent;

--- a/src/ui/units/dash/store/actions/dashTyped.ts
+++ b/src/ui/units/dash/store/actions/dashTyped.ts
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import {AddConfigItem, Config, DashKit, ItemsStateAndParams} from '@gravity-ui/dashkit';
+import {
+    AddConfigItem,
+    Config,
+    DashKit,
+    ItemsStateAndParams,
+    type StringParams,
+} from '@gravity-ui/dashkit';
 import {PluginTextProps} from '@gravity-ui/dashkit/build/esm/plugins/Text/Text';
 import {PluginTitleProps} from '@gravity-ui/dashkit/build/esm/plugins/Title/Title';
 import {i18n} from 'i18n';
@@ -368,6 +374,7 @@ export type SelectorDialogState = {
     dataset?: Dataset;
     datasetId?: string;
     connectionId?: string;
+    selectorParameters?: StringParams;
     connectionQueryType?: ConnectionQueryTypeValues;
     connectionQueryTypes?: ConnectionQueryTypeOptions[];
     connectionQueryContent?: ConnectionQueryContent;

--- a/src/ui/units/dash/store/reducers/dash.js
+++ b/src/ui/units/dash/store/reducers/dash.js
@@ -85,7 +85,10 @@ export function getSelectorDialogInitialState(args = {}) {
 }
 
 export function getSelectorDialogFromData(data, defaults) {
-    const selectorParameters = omit(defaults || {}, data.fieldName);
+    const selectorParameters = omit(
+        data.source.selectorParameters || defaults || {},
+        data.fieldName,
+    );
 
     return {
         validation: {},

--- a/src/ui/units/dash/store/reducers/dash.js
+++ b/src/ui/units/dash/store/reducers/dash.js
@@ -1,6 +1,7 @@
 import {DashKit, generateUniqId} from '@gravity-ui/dashkit';
 import {I18n} from 'i18n';
 import update from 'immutability-helper';
+import {omit} from 'lodash';
 import pick from 'lodash/pick';
 import {DashTabItemControlSourceType, DashTabItemType, Feature} from 'shared';
 import {getRandomKey} from 'ui/libs/DatalensChartkit/helpers/helpers';
@@ -84,6 +85,8 @@ export function getSelectorDialogInitialState(args = {}) {
 }
 
 export function getSelectorDialogFromData(data, defaults) {
+    const selectorParameters = omit(defaults || {}, data.fieldName);
+
     return {
         validation: {},
         isManualTitle: true,
@@ -96,6 +99,7 @@ export function getSelectorDialogFromData(data, defaults) {
 
         datasetId: data.source.datasetId,
         connectionId: data.source.connectionId,
+        selectorParameters,
         connectionQueryType: data.source.connectionQueryType,
         connectionQueryTypes: data.source.connectionQueryTypes,
         connectionQueryContent: data.source.connectionQueryContent,

--- a/src/ui/units/dash/store/reducers/dash.js
+++ b/src/ui/units/dash/store/reducers/dash.js
@@ -1,9 +1,9 @@
 import {DashKit, generateUniqId} from '@gravity-ui/dashkit';
 import {I18n} from 'i18n';
 import update from 'immutability-helper';
-import {omit} from 'lodash';
 import pick from 'lodash/pick';
 import {DashTabItemControlSourceType, DashTabItemType, Feature} from 'shared';
+import {extractTypedQueryParams} from 'shared/modules/typed-query-api/helpers/parameters';
 import {getRandomKey} from 'ui/libs/DatalensChartkit/helpers/helpers';
 import {ELEMENT_TYPE} from 'units/dash/containers/Dialogs/Control/constants';
 import Utils from 'utils';
@@ -85,10 +85,18 @@ export function getSelectorDialogInitialState(args = {}) {
 }
 
 export function getSelectorDialogFromData(data, defaults) {
-    const selectorParameters = omit(
-        data.source.selectorParameters || defaults || {},
-        data.fieldName,
-    );
+    let selectorParameters;
+
+    switch (data.source.sourceType) {
+        case DashTabItemControlSourceType.Connection:
+            selectorParameters = extractTypedQueryParams(defaults, data.source.fieldName);
+            break;
+        case DashTabItemControlSourceType.External:
+            selectorParameters = defaults;
+            break;
+        default:
+            selectorParameters = {};
+    }
 
     return {
         validation: {},

--- a/src/ui/units/dash/store/reducers/dash.js
+++ b/src/ui/units/dash/store/reducers/dash.js
@@ -87,7 +87,7 @@ export function getSelectorDialogInitialState(args = {}) {
 export function getSelectorDialogFromData(data, defaults) {
     let selectorParameters;
 
-    switch (data.source.sourceType) {
+    switch (data.sourceType) {
         case DashTabItemControlSourceType.Connection:
             selectorParameters = extractTypedQueryParams(defaults, data.source.fieldName);
             break;

--- a/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
+++ b/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
@@ -86,6 +86,19 @@ export const selectIsControlConfigurationDisabled = (state: DatalensGlobalState)
     }
 };
 
+export const selectIsParametersSectionAvailable = (state: DatalensGlobalState): boolean => {
+    const {sourceType, connectionId, connectionQueryTypes} = state.dash.selectorDialog;
+
+    switch (sourceType) {
+        case DashTabItemControlSourceType.Connection:
+            return Boolean(
+                connectionId && connectionQueryTypes?.length && connectionQueryTypes.length > 0,
+            );
+        default:
+            return false;
+    }
+};
+
 export const selectAvailableOperationsDict = (
     state: DatalensGlobalState,
 ): Record<Operations, boolean> | undefined => {

--- a/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
+++ b/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
@@ -92,6 +92,8 @@ export const selectIsParametersSectionAvailable = (state: DatalensGlobalState): 
     switch (sourceType) {
         case DashTabItemControlSourceType.Connection:
             return Boolean(connectionId && connectionQueryTypes?.length);
+        case DashTabItemControlSourceType.External:
+            return true;
         default:
             return false;
     }

--- a/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
+++ b/src/ui/units/dash/store/selectors/dashTypedSelectors.ts
@@ -91,9 +91,7 @@ export const selectIsParametersSectionAvailable = (state: DatalensGlobalState): 
 
     switch (sourceType) {
         case DashTabItemControlSourceType.Connection:
-            return Boolean(
-                connectionId && connectionQueryTypes?.length && connectionQueryTypes.length > 0,
-            );
+            return Boolean(connectionId && connectionQueryTypes?.length);
         default:
             return false;
     }


### PR DESCRIPTION
Related to the [issue](https://github.com/datalens-tech/datalens-ui/issues/653). I've added support defining and processing parameters created inside connection based control.

All functionality are hidden behind feature flag `ConnectionBasedControl`