### PR TITLE
Separate E2E and statoscope sticky report comments

### DIFF
--- a/.github/workflows/e2e_tests_report.yml
+++ b/.github/workflows/e2e_tests_report.yml
@@ -67,5 +67,6 @@ jobs:
       - name: Create Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: e2e-report
           number: ${{ env.REPORT_PR_NUMBER }}
           message: '[E2E Report](https://datalens-tech.github.io/datalens-ui/${{ env.HTML_REPORT_URL_PATH }}/report) is ready.'

--- a/.github/workflows/statoscope_tests_report.yml
+++ b/.github/workflows/statoscope_tests_report.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Create Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: statoscope-report
           number: ${{ steps.extract-data.outputs.REPORT_PR_NUMBER }}
           message: "${{steps.create-comment-text.outputs.result}}"
     


### PR DESCRIPTION
Now the e2e and statoscope reports are rewriting each other. We need to separate them.

<img width="696" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/1742586/c45713a1-b0cc-4e39-93e2-5dcd939d06c2">


