### PR TITLE
Clean up backwards campatibility

### DIFF
--- a/src/ui/components/FieldEditor/components/helpers.ts
+++ b/src/ui/components/FieldEditor/components/helpers.ts
@@ -10,25 +10,5 @@ export async function fetchFunctionsDocumentation(docsEndpoint: string, path: st
         'fetchFunctionsDocumentation',
     );
 
-    // Temporary backwards compatible tweak to support old version of `fetchFunctionsDocumentation`
-    // that doesn't process html itself.
-    // Will be removed in next PR.
-    if (fetchFunctionsDocumentation.length === 1) {
-        const functionDoc = await fetchFunctionsDocumentation(path);
-        functionDoc.html = functionDoc.html
-            // Remove all icons from buttons to copy text
-            .replace(/<svg[^>]*>/gs, '')
-            // Make Cloud Documentation references
-            // Delete anchor and external references
-            .replace(
-                /href=(["'])(?!http|#)(.+?)\1/gs,
-                (_linkAttr: string, _quote: string, functionName: string) => {
-                    return `href="${docsEndpoint}/function-ref/${functionName}" target="_blank"`;
-                },
-            );
-
-        return functionDoc;
-    }
-
     return await fetchFunctionsDocumentation(docsEndpoint, path);
 }

--- a/src/ui/registry/units/common/functions-map.ts
+++ b/src/ui/registry/units/common/functions-map.ts
@@ -86,7 +86,7 @@ export const commonFunctionsMap = {
         makeFunctionTemplate<() => Promise<GetFunctionsDocumentationResponse>>(),
     fetchFunctionsDocumentation:
         makeFunctionTemplate<
-            (docsEndpoint: string, path?: string) => Promise<FetchFunctionsDocumentationResponse>
+            (docsEndpoint: string, path: string) => Promise<FetchFunctionsDocumentationResponse>
         >(),
     isEntryId: makeFunctionTemplate<(value: string) => boolean>(),
     extractEntryId: makeFunctionTemplate<(value?: string) => string | null>(),


### PR DESCRIPTION
Rebased version of https://github.com/datalens-tech/datalens-ui/pull/86.

Require update of `fetchFunctionsDocumentation` in places of usage:
```
// from
fetchFunctionsDocumentation(docsEndpoint: string, path?: string) ...
// to
fetchFunctionsDocumentation(docsEndpoint: string, path: string) ...
```