### PR TITLE
Add text&title widget autoheight support

### DIFF
--- a/src/i18n-keysets/dash.dashkit-plugin-common.view/en.json
+++ b/src/i18n-keysets/dash.dashkit-plugin-common.view/en.json
@@ -1,0 +1,3 @@
+{
+  "label_autoheight-checkbox": "Autoheight"
+}

--- a/src/i18n-keysets/dash.dashkit-plugin-common.view/ru.json
+++ b/src/i18n-keysets/dash.dashkit-plugin-common.view/ru.json
@@ -1,0 +1,3 @@
+{
+  "label_autoheight-checkbox": "Автовысота"
+}

--- a/src/shared/types/dash.ts
+++ b/src/shared/types/dash.ts
@@ -116,6 +116,7 @@ export interface DashTabItemText extends DashTabItemBase {
     type: DashTabItemType.Text;
     data: {
         text: string;
+        autoHeight?: boolean;
     };
 }
 

--- a/src/shared/types/dash.ts
+++ b/src/shared/types/dash.ts
@@ -126,6 +126,7 @@ export interface DashTabItemTitle extends DashTabItemBase {
         text: string;
         size: DashTabItemTitleSize;
         showInTOC: boolean;
+        autoHeight?: boolean;
     };
 }
 

--- a/src/ui/components/DashKit/plugins/RendererWrapper/RendererWrapper.tsx
+++ b/src/ui/components/DashKit/plugins/RendererWrapper/RendererWrapper.tsx
@@ -8,10 +8,13 @@ const b = block('dashkit-plugin-container');
 
 type RendererProps = {
     type: 'widget' | 'text';
+    nodeRef?: React.RefObject<HTMLDivElement>;
 };
 
-export const RendererWrapper: React.FC<RendererProps> = React.memo(({children, type}) => (
-    <div className={b('wrapper', {[type]: Boolean(type)})}>{children}</div>
+export const RendererWrapper: React.FC<RendererProps> = React.memo(({children, type, nodeRef}) => (
+    <div ref={nodeRef} className={b('wrapper', {[type]: Boolean(type)})}>
+        {children}
+    </div>
 ));
 
 RendererWrapper.displayName = 'RendererWrapper';

--- a/src/ui/components/DashKit/plugins/RendererWrapper/RendererWrapper.tsx
+++ b/src/ui/components/DashKit/plugins/RendererWrapper/RendererWrapper.tsx
@@ -6,8 +6,10 @@ import './RendererWrapper.scss';
 
 const b = block('dashkit-plugin-container');
 
+export const RENDERER_WRAPPER_CLASSNAME = b();
+
 type RendererProps = {
-    type: 'widget' | 'text';
+    type: 'widget' | 'text' | 'title';
     nodeRef?: React.RefObject<HTMLDivElement>;
 };
 

--- a/src/ui/components/DashKit/plugins/Text/Text.tsx
+++ b/src/ui/components/DashKit/plugins/Text/Text.tsx
@@ -7,6 +7,8 @@ import {
     pluginText,
 } from '@gravity-ui/dashkit';
 import block from 'bem-cn-lite';
+import {adjustWidgetLayout as dashkitAdjustWidgetLayout} from 'ui/components/DashKit/utils';
+import {YFM_MARKDOWN_CLASSNAME} from 'ui/constants/yfm';
 
 import {getRandomCKId} from '../../../../libs/DatalensChartkit/ChartKit/helpers/getRandomCKId';
 import {YfmWrapper} from '../../../YfmWrapper/YfmWrapper';
@@ -31,6 +33,9 @@ const textPlugin = {
     ) {
         const [textReady, setTextReady] = React.useState<string>('');
         const [randomId, setRandomId] = React.useState<string>('');
+        const rootNodeRef = React.useRef<HTMLDivElement>(null);
+        const cutNodesRef = React.useRef<NodeList | null>(null);
+        const mutationObserver = React.useRef<MutationObserver | null>(null);
 
         /**
          * get prepared text with markdown
@@ -44,6 +49,33 @@ const textPlugin = {
             [pluginText._apiHandler],
         );
 
+        /**
+         * call common for charts & selectors adjust function for widget
+         */
+        const adjustLayout = React.useCallback(
+            (needSetDefault) => {
+                dashkitAdjustWidgetLayout({
+                    widgetId: props.id,
+                    needSetDefault,
+                    rootNode: rootNodeRef,
+                    gridLayout: props.gridLayout,
+                    layout: props.layout,
+                    cb: props.adjustWidgetLayout,
+                    mainNodeSelector: `.${YFM_MARKDOWN_CLASSNAME}.${b()}`,
+                    scrollableNodeSelector: `.${YFM_MARKDOWN_CLASSNAME} .${YFM_MARKDOWN_CLASSNAME}`,
+                });
+            },
+            [props.id, rootNodeRef, props.adjustWidgetLayout, props.layout, props.gridLayout],
+        );
+
+        /**
+         * call adjust function after all text was rendered (ketex formulas, markdown, etc)
+         * and after cut opened/closed
+         */
+        const handleTextRender = React.useCallback(() => {
+            adjustLayout(!props.data.autoHeight);
+        }, [props.data.autoHeight, adjustLayout]);
+
         const content = <PluginText {...props} apiHandler={textHandler} ref={forwardedRef} />;
 
         /**
@@ -53,11 +85,40 @@ const textPlugin = {
             setRandomId(String(getRandomCKId()));
         }, [textReady]);
 
+        /**
+         * watching content changes to check if adjustLayout needed for autoheight widgets update
+         */
+        React.useEffect(() => {
+            if (!mutationObserver) {
+                return;
+            }
+            mutationObserver.current = new MutationObserver(handleTextRender);
+
+            if (mutationObserver.current && cutNodesRef.current) {
+                cutNodesRef.current.forEach((cutNode) => {
+                    mutationObserver.current?.observe(cutNode, {
+                        attributes: true,
+                        attributeFilter: ['class'],
+                    });
+                });
+            }
+            return () => {
+                mutationObserver.current?.disconnect();
+            };
+        }, [handleTextRender, mutationObserver, rootNodeRef, cutNodesRef.current]);
+
+        const nodes = rootNodeRef.current?.querySelectorAll(`.${YFM_MARKDOWN_CLASSNAME}-cut`);
+
+        if (nodes?.length && !cutNodesRef.current) {
+            cutNodesRef.current = nodes;
+        }
+
         return (
-            <RendererWrapper type="text">
+            <RendererWrapper type="text" nodeRef={rootNodeRef}>
                 <YfmWrapper
                     content={<div className={b('content-wrap', null, randomId)}>{content}</div>}
                     className={b()}
+                    onRenderCallback={handleTextRender}
                 />
             </RendererWrapper>
         );

--- a/src/ui/components/DashKit/plugins/Title/Title.scss
+++ b/src/ui/components/DashKit/plugins/Title/Title.scss
@@ -1,6 +1,16 @@
 .dashkit-plugin-title-container {
     height: 100%;
 
+    &_with-auto-height {
+        overflow-x: hidden;
+        overflow-y: auto;
+
+        [data-plugin-root-el='title'] {
+            height: auto;
+            padding-top: 10px;
+        }
+    }
+
     .dashkit-grid-item__item_editMode & {
         background-color: var(--g-color-base-float);
     }

--- a/src/ui/components/DashKit/plugins/Title/Title.scss
+++ b/src/ui/components/DashKit/plugins/Title/Title.scss
@@ -2,7 +2,6 @@
     height: 100%;
 
     &_with-auto-height {
-        overflow-x: hidden;
         overflow-y: auto;
 
         [data-plugin-root-el='title'] {

--- a/src/ui/components/DashKit/plugins/Title/Title.tsx
+++ b/src/ui/components/DashKit/plugins/Title/Title.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
-import {
-    PLUGIN_ROOT_ATTR_NAME,
-    PluginTitle,
-    PluginTitleProps,
-    pluginTitle,
-} from '@gravity-ui/dashkit';
+import {PluginTitle, PluginTitleProps, pluginTitle} from '@gravity-ui/dashkit';
 import block from 'bem-cn-lite';
 import {adjustWidgetLayout as dashkitAdjustWidgetLayout} from 'ui/components/DashKit/utils';
+
+import {RENDERER_WRAPPER_CLASSNAME, RendererWrapper} from '../RendererWrapper/RendererWrapper';
 
 import './Title.scss';
 
@@ -35,26 +32,25 @@ const titlePlugin = {
                     gridLayout: props.gridLayout,
                     layout: props.layout,
                     cb: props.adjustWidgetLayout,
-                    mainNodeSelector: `.${b()}`,
-                    scrollableNodeSelector: `[${PLUGIN_ROOT_ATTR_NAME}="title"]`,
+                    mainNodeSelector: `.${RENDERER_WRAPPER_CLASSNAME}`,
+                    scrollableNodeSelector: `.${b()}`,
                 });
             },
             [props.id, rootNodeRef, props.adjustWidgetLayout, props.layout, props.gridLayout],
         );
 
-        React.useLayoutEffect(() => {
+        React.useEffect(() => {
             adjustLayout(!props.data.autoHeight);
         }, [adjustLayout, props.data.autoHeight]);
 
         const content = <PluginTitle {...props} ref={forwardedRef} />;
 
         return (
-            <div
-                className={b({'with-auto-height': Boolean(props.data.autoHeight)})}
-                ref={rootNodeRef}
-            >
-                {content}
-            </div>
+            <RendererWrapper type="title" nodeRef={rootNodeRef}>
+                <div className={b({'with-auto-height': Boolean(props.data.autoHeight)})}>
+                    {content}
+                </div>
+            </RendererWrapper>
         );
     },
 };

--- a/src/ui/components/DashKit/plugins/Title/Title.tsx
+++ b/src/ui/components/DashKit/plugins/Title/Title.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
-import {PluginTitle, PluginTitleProps, pluginTitle} from '@gravity-ui/dashkit';
+import {
+    PLUGIN_ROOT_ATTR_NAME,
+    PluginTitle,
+    PluginTitleProps,
+    pluginTitle,
+} from '@gravity-ui/dashkit';
 import block from 'bem-cn-lite';
+import {adjustWidgetLayout as dashkitAdjustWidgetLayout} from 'ui/components/DashKit/utils';
 
 import './Title.scss';
 
@@ -15,9 +21,41 @@ const titlePlugin = {
         props: Props,
         forwardedRef: React.LegacyRef<PluginTitle> | undefined,
     ) {
+        const rootNodeRef = React.useRef<HTMLDivElement>(null);
+
+        /**
+         * call common for charts & selectors adjust function for widget
+         */
+        const adjustLayout = React.useCallback(
+            (needSetDefault) => {
+                dashkitAdjustWidgetLayout({
+                    widgetId: props.id,
+                    needSetDefault,
+                    rootNode: rootNodeRef,
+                    gridLayout: props.gridLayout,
+                    layout: props.layout,
+                    cb: props.adjustWidgetLayout,
+                    mainNodeSelector: `.${b()}`,
+                    scrollableNodeSelector: `[${PLUGIN_ROOT_ATTR_NAME}="title"]`,
+                });
+            },
+            [props.id, rootNodeRef, props.adjustWidgetLayout, props.layout, props.gridLayout],
+        );
+
+        React.useLayoutEffect(() => {
+            adjustLayout(!props.data.autoHeight);
+        }, [adjustLayout, props.data.autoHeight]);
+
         const content = <PluginTitle {...props} ref={forwardedRef} />;
 
-        return <div className={b()}>{content}</div>;
+        return (
+            <div
+                className={b({'with-auto-height': Boolean(props.data.autoHeight)})}
+                ref={rootNodeRef}
+            >
+                {content}
+            </div>
+        );
     },
 };
 

--- a/src/ui/components/DashKit/utils.ts
+++ b/src/ui/components/DashKit/utils.ts
@@ -38,6 +38,8 @@ export type AdjustWidgetLayoutProps = {
     gridLayout: PluginWidgetProps['gridLayout'];
     layout: PluginWidgetProps['layout'];
     cb: PluginWidgetProps['adjustWidgetLayout'];
+    mainNodeSelector?: string;
+    scrollableNodeSelector?: string;
 };
 
 const getScrollbarWidth = (node: HTMLElement) => node.offsetWidth - node.clientWidth;
@@ -106,6 +108,8 @@ export function adjustWidgetLayout({
     gridLayout,
     layout,
     cb,
+    mainNodeSelector,
+    scrollableNodeSelector,
 }: AdjustWidgetLayoutProps) {
     if (DL.IS_MOBILE || needSetDefault) {
         cb({widgetId, needSetDefault});
@@ -118,9 +122,9 @@ export function adjustWidgetLayout({
     }
 
     const scrollableNode = node.querySelector(
-        `.${CHARTKIT_SCROLLABLE_NODE_CLASSNAME}`,
+        scrollableNodeSelector || `.${CHARTKIT_SCROLLABLE_NODE_CLASSNAME}`,
     ) as HTMLElement | null;
-    const mainNode = node.querySelector(`.${CHARTKIT_MAIN_CLASSNAME}`);
+    const mainNode = node.querySelector(mainNodeSelector || `.${CHARTKIT_MAIN_CLASSNAME}`);
     const errorNode = node.querySelector(`.${CHARTKIT_ERROR_NODE_CLASSNAME}`);
 
     const rootNodeTopPosition = node.getBoundingClientRect().top;

--- a/src/ui/components/TextEditor/TextEditor.scss
+++ b/src/ui/components/TextEditor/TextEditor.scss
@@ -21,6 +21,7 @@
         align-items: center;
         color: var(--g-color-text-secondary);
         line-height: 24px;
+        margin-top: 4px;
     }
 
     &__info-text {

--- a/src/ui/components/YfmWrapper/YfmWrapper.tsx
+++ b/src/ui/components/YfmWrapper/YfmWrapper.tsx
@@ -11,7 +11,9 @@ export const YfmWrapper = React.forwardRef<HTMLDivElement, Omit<YfmWrapperProps,
         const renderLatex = useLatex();
 
         React.useLayoutEffect(() => {
-            renderLatex();
+            renderLatex().then(() => {
+                props.onRenderCallback?.();
+            });
         });
 
         React.useEffect(() => {

--- a/src/ui/registry/units/common/types/components/YfmWrapper.ts
+++ b/src/ui/registry/units/common/types/components/YfmWrapper.ts
@@ -6,4 +6,5 @@ export type YfmWrapperProps = {
     className?: string;
     noMagicLinks?: boolean;
     ref?: React.Ref<HTMLDivElement>;
+    onRenderCallback?: () => void;
 };

--- a/src/ui/units/dash/containers/Dialogs/Text/Text.scss
+++ b/src/ui/units/dash/containers/Dialogs/Text/Text.scss
@@ -8,4 +8,8 @@
         color: var(--g-color-text-secondary);
         margin-top: 10px;
     }
+
+    &__setting-row {
+        margin-top: 20px;
+    }
 }

--- a/src/ui/units/dash/containers/Dialogs/Text/Text.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Text/Text.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import {Dialog} from '@gravity-ui/uikit';
+import {Checkbox, Dialog} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
-import {I18n} from 'i18n';
+import {i18n} from 'i18n';
 import {ResolveThunks, connect} from 'react-redux';
 import {DashTabItemText, DialogDashWidgetItemQA, DialogDashWidgetQA} from 'shared';
 import {DatalensGlobalState} from 'ui';
@@ -20,8 +20,6 @@ import './Text.scss';
 
 const b = block('dialog-text');
 
-const i18n = I18n.keyset('dash.text-dialog.edit');
-
 export interface OwnProps {}
 
 type StateProps = ReturnType<typeof mapStateToProps>;
@@ -30,6 +28,7 @@ type DispatchProps = ResolveThunks<typeof mapDispatchToProps>;
 interface State {
     text?: string;
     prevVisible?: boolean;
+    autoHeight?: boolean;
 }
 
 export type TextProps = OwnProps & StateProps & DispatchProps;
@@ -38,6 +37,7 @@ class Text extends React.PureComponent<TextProps, State> {
     static defaultProps = {
         data: {
             text: '',
+            autoHeight: false,
         },
     };
 
@@ -49,6 +49,7 @@ class Text extends React.PureComponent<TextProps, State> {
         return {
             prevVisible: nextProps.visible,
             text: nextProps.data.text,
+            autoHeight: Boolean(nextProps.data.autoHeight),
         };
     }
 
@@ -56,7 +57,7 @@ class Text extends React.PureComponent<TextProps, State> {
 
     render() {
         const {id, visible} = this.props;
-        const {text} = this.state;
+        const {text, autoHeight} = this.state;
 
         return (
             <Dialog
@@ -66,15 +67,27 @@ class Text extends React.PureComponent<TextProps, State> {
                 disableFocusTrap={true}
                 qa={DialogDashWidgetItemQA.Text}
             >
-                <Dialog.Header caption={i18n('label_text')} />
+                <Dialog.Header caption={i18n('dash.text-dialog.edit', 'label_text')} />
                 <Dialog.Body className={b()}>
                     <TextEditor autofocus onTextUpdate={this.onTextUpdate} text={text} />
+                    <div className={b('setting-row')}>
+                        <Checkbox
+                            checked={Boolean(autoHeight)}
+                            onChange={this.handleAutoHeightChanged}
+                        >
+                            {i18n('dash.dashkit-plugin-common.view', 'label_autoheight-checkbox')}
+                        </Checkbox>
+                    </div>
                 </Dialog.Body>
                 <Dialog.Footer
                     onClickButtonApply={this.onApply}
-                    textButtonApply={id ? i18n('button_save') : i18n('button_add')}
+                    textButtonApply={
+                        id
+                            ? i18n('dash.text-dialog.edit', 'button_save')
+                            : i18n('dash.text-dialog.edit', 'button_add')
+                    }
                     onClickButtonCancel={this.props.closeDialog}
-                    textButtonCancel={i18n('button_cancel')}
+                    textButtonCancel={i18n('dash.text-dialog.edit', 'button_cancel')}
                     propsButtonApply={{qa: DialogDashWidgetQA.Apply}}
                     propsButtonCancel={{qa: DialogDashWidgetQA.Cancel}}
                 />
@@ -85,10 +98,14 @@ class Text extends React.PureComponent<TextProps, State> {
     onTextUpdate = (text: string) => this.setState({text});
 
     onApply = () => {
-        const {text} = this.state;
+        const {text, autoHeight} = this.state;
 
-        this.props.setItemData({data: {text}});
+        this.props.setItemData({data: {text, autoHeight}});
         this.props.closeDialog();
+    };
+
+    handleAutoHeightChanged = () => {
+        this.setState({autoHeight: !this.state.autoHeight});
     };
 }
 

--- a/src/ui/units/dash/containers/Dialogs/Title/Title.scss
+++ b/src/ui/units/dash/containers/Dialogs/Title/Title.scss
@@ -30,7 +30,11 @@
         }
     }
 
-    &__checkbox {
+    &__setting-row {
         margin-top: 30px;
+    }
+
+    &__setting-row + &__setting-row {
+        margin-top: 10px;
     }
 }

--- a/src/ui/units/dash/containers/Dialogs/Title/Title.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Title/Title.tsx
@@ -118,7 +118,7 @@ class Title extends React.PureComponent<Props, State> {
                             checked={Boolean(autoHeight)}
                             onChange={this.handleAutoHeightChanged}
                         >
-                            Autoheight
+                            {i18n('dash.dashkit-plugin-common.view', 'label_autoheight-checkbox')}
                         </Checkbox>
                     </div>
                 </Dialog.Body>

--- a/src/ui/units/dash/containers/Dialogs/Title/Title.tsx
+++ b/src/ui/units/dash/containers/Dialogs/Title/Title.tsx
@@ -41,6 +41,7 @@ interface State {
     text?: string;
     size?: string;
     showInTOC?: boolean;
+    autoHeight?: boolean;
 }
 
 type Props = OwnProps & StateProps & DispatchProps;
@@ -51,6 +52,7 @@ class Title extends React.PureComponent<Props, State> {
             text: i18n('dash.title-dialog.edit', 'value_default'),
             size: SIZES[0],
             showInTOC: true,
+            autoHeight: false,
         } as DashTabItemTitle['data'],
     };
 
@@ -65,6 +67,7 @@ class Title extends React.PureComponent<Props, State> {
             text: nextProps.data.text,
             size: nextProps.data.size,
             showInTOC: nextProps.data.showInTOC,
+            autoHeight: Boolean(nextProps.data.autoHeight),
         };
     }
 
@@ -72,7 +75,7 @@ class Title extends React.PureComponent<Props, State> {
 
     render() {
         const {id, visible} = this.props;
-        const {text, size, showInTOC, validation} = this.state;
+        const {text, size, showInTOC, validation, autoHeight} = this.state;
         return (
             <Dialog
                 open={visible}
@@ -99,16 +102,25 @@ class Title extends React.PureComponent<Props, State> {
                         radioText={RADIO_TEXT}
                         onChange={this.onSizeChange}
                     />
-                    <Checkbox
-                        size="l"
-                        checked={showInTOC}
-                        onChange={() =>
-                            this.setState((prevState) => ({showInTOC: !prevState.showInTOC}))
-                        }
-                        className={b('checkbox')}
-                    >
-                        {i18n('dash.title-dialog.edit', 'field_show-in-toc')}
-                    </Checkbox>
+                    <div className={b('setting-row')}>
+                        <Checkbox
+                            checked={showInTOC}
+                            onChange={() =>
+                                this.setState((prevState) => ({showInTOC: !prevState.showInTOC}))
+                            }
+                            className={b('checkbox')}
+                        >
+                            {i18n('dash.title-dialog.edit', 'field_show-in-toc')}
+                        </Checkbox>
+                    </div>
+                    <div className={b('setting-row')}>
+                        <Checkbox
+                            checked={Boolean(autoHeight)}
+                            onChange={this.handleAutoHeightChanged}
+                        >
+                            Autoheight
+                        </Checkbox>
+                    </div>
                 </Dialog.Body>
                 <Dialog.Footer
                     onClickButtonApply={this.onApply}
@@ -135,13 +147,14 @@ class Title extends React.PureComponent<Props, State> {
     onSizeChange = (size?: string) => this.setState({size});
 
     onApply = () => {
-        const {text, size, showInTOC} = this.state;
+        const {text, size, showInTOC, autoHeight} = this.state;
         if (text?.trim()) {
             this.props.setItemData({
                 data: {
                     text,
                     size,
                     showInTOC,
+                    autoHeight,
                 },
             });
             this.props.closeDialog();
@@ -152,6 +165,10 @@ class Title extends React.PureComponent<Props, State> {
                 },
             });
         }
+    };
+
+    handleAutoHeightChanged = () => {
+        this.setState({autoHeight: !this.state.autoHeight});
     };
 }
 


### PR DESCRIPTION
Added "Autoheight" setting to text and title widgets.

<img width="1054" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/6c5c8f2f-50b1-4695-8a0b-7d3286c02478">

<img width="1050" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/c0e6ed16-cd58-4eb3-8623-c066ae72215a">

<img width="1181" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/3c9eb3de-a482-4fa2-85cf-f4c7a942c613">
