### PR TITLE
Fix color and ellipsis styles in Breadcrumbs

### DIFF
--- a/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
+++ b/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
@@ -1,4 +1,5 @@
 @import '~@gravity-ui/uikit/styles/mixins';
+@import '../../../../styles/mixins';
 
 .dl-entry-panel {
     $class: &;
@@ -64,22 +65,7 @@
         margin-right: 8px;
     }
 
-    &__item,
-    &__item:visited,
-    &__item:active {
-        color: var(--g-color-text-secondary);
-    }
-
     &__item {
-        display: inline;
-        text-decoration: none;
-
-        &:hover {
-            color: var(--g-color-text-primary);
-        }
-
-        &_link:hover {
-            color: var(--g-color-text-link-hover);
-        }
+        @include dl-breadcrumbs-items-style;
     }
 }

--- a/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
+++ b/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
@@ -68,15 +68,18 @@
     &__item:visited,
     &__item:active {
         color: var(--g-color-text-secondary);
+    }
+
+    &__item {
         display: inline;
         text-decoration: none;
 
-        &_link:hover {
-            color: var(--g-color-text-link-hover);
-        }
-
         &:hover {
             color: var(--g-color-text-primary);
+        }
+
+        &_link:hover {
+            color: var(--g-color-text-link-hover);
         }
     }
 }

--- a/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
+++ b/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.scss
@@ -63,4 +63,20 @@
     &__cloud-select-container {
         margin-right: 8px;
     }
+
+    &__item,
+    &__item:visited,
+    &__item:active {
+        color: var(--g-color-text-secondary);
+        display: inline;
+        text-decoration: none;
+
+        &_link:hover {
+            color: var(--g-color-text-link-hover);
+        }
+
+        &:hover {
+            color: var(--g-color-text-primary);
+        }
+    }
 }

--- a/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.tsx
+++ b/src/ui/components/ActionPanel/components/EntryPanel/EntryPanel.tsx
@@ -307,21 +307,25 @@ class EntryPanel extends React.Component<Props, State> {
     }
 
     private renderRootContent = (rootItem: BreadcrumbsItem) => {
-        if ((this.props.entry as any | undefined)?.fake) {
-            return rootItem.text;
+        if (rootItem.href) {
+            return (
+                <Link
+                    key={rootItem.text}
+                    view="secondary"
+                    href={rootItem.href}
+                    title={rootItem.text}
+                    onClick={rootItem.action}
+                    className={b('item', {link: true})}
+                >
+                    {rootItem.text}
+                </Link>
+            );
         }
 
         return (
-            <Link
-                key={rootItem.text}
-                view="secondary"
-                href={rootItem.href || '#'}
-                title={rootItem.text}
-                onClick={rootItem.action}
-                className={b('item')}
-            >
+            <div key={rootItem.text} className={b('item')}>
                 {rootItem.text}
-            </Link>
+            </div>
         );
     };
 

--- a/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
+++ b/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
@@ -2,20 +2,24 @@
 
 .entry-panel-breadcrumbs {
     max-width: var(--dl-breadcrumbs-max-width);
+    margin-right: 5px;
 
     &__item,
     &__item:visited,
     &__item:active {
         color: var(--g-color-text-secondary);
+    }
+
+    &__item {
         display: inline;
         text-decoration: none;
 
-        &_link:hover {
-            color: var(--g-color-text-link-hover);
-        }
-
         &:hover {
             color: var(--g-color-text-primary);
+        }
+
+        &_link:hover {
+            color: var(--g-color-text-link-hover);
         }
     }
 }

--- a/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
+++ b/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
@@ -3,14 +3,19 @@
 .entry-panel-breadcrumbs {
     max-width: var(--dl-breadcrumbs-max-width);
 
-    &__item {
-        color: var(--g-color-text-primary);
+    &__item,
+    &__item:visited,
+    &__item:active {
+        color: var(--g-color-text-secondary);
+        display: inline;
         text-decoration: none;
 
-        &:hover,
-        &:visited,
-        &:active {
-            color: var(--g-color-text-secondary);
+        &_link:hover {
+            color: var(--g-color-text-link-hover);
+        }
+
+        &:hover {
+            color: var(--g-color-text-primary);
         }
     }
 }

--- a/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
+++ b/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.scss
@@ -1,25 +1,11 @@
 @import '~@gravity-ui/uikit/styles/mixins';
+@import '../../styles/mixins.scss';
 
 .entry-panel-breadcrumbs {
     max-width: var(--dl-breadcrumbs-max-width);
     margin-right: 5px;
 
-    &__item,
-    &__item:visited,
-    &__item:active {
-        color: var(--g-color-text-secondary);
-    }
-
     &__item {
-        display: inline;
-        text-decoration: none;
-
-        &:hover {
-            color: var(--g-color-text-primary);
-        }
-
-        &_link:hover {
-            color: var(--g-color-text-link-hover);
-        }
+        @include dl-breadcrumbs-items-style;
     }
 }

--- a/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.tsx
+++ b/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.tsx
@@ -36,11 +36,15 @@ export const EntryBreadcrumbs = (props: EntryBreadcrumbsProps) => {
             firstDisplayedItemsCount={FirstDisplayedItemsCount.One}
             lastDisplayedItemsCount={LastDisplayedItemsCount.One}
             renderRootContent={entry?.workbookId ? undefined : renderRootContent}
-            renderItemContent={(item: BreadcrumbsItem) => {
+            renderItemContent={(item: BreadcrumbsItem, isCurrent: boolean) => {
+                if (isCurrent) {
+                    return item.text;
+                }
+
                 return item.path ? (
                     <Link
                         to={item.path}
-                        className={b('item')}
+                        className={b('item', {link: true})}
                         onClick={(e) => {
                             e.stopPropagation();
                         }}

--- a/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.tsx
+++ b/src/ui/components/EntryBreadcrumbs/EntryBreadcrumbs.tsx
@@ -48,7 +48,7 @@ export const EntryBreadcrumbs = (props: EntryBreadcrumbsProps) => {
                         {item.text}
                     </Link>
                 ) : (
-                    <div>{item.text}</div>
+                    <div className={b('item')}>{item.text}</div>
                 );
             }}
         />

--- a/src/ui/components/Navigation/Core/NavigationBreadcrumbs/NavigationBreadcrumbs.scss
+++ b/src/ui/components/Navigation/Core/NavigationBreadcrumbs/NavigationBreadcrumbs.scss
@@ -29,4 +29,8 @@
     &__item_last {
         font-weight: 500;
     }
+
+    &__item:not(&__item_last):hover {
+        color: var(--g-color-text-primary);
+    }
 }

--- a/src/ui/styles/mixins.scss
+++ b/src/ui/styles/mixins.scss
@@ -141,3 +141,22 @@
     // $height - [dialog header height] - [dialog footer height] - [body padding]
     max-height: calc($height - 54px - 92px - 20px);
 }
+
+@mixin dl-breadcrumbs-items-style {
+    &,
+    &:visited,
+    &:active {
+        color: var(--g-color-text-secondary);
+    }
+
+    display: inline;
+    text-decoration: none;
+
+    &:hover {
+        color: var(--g-color-text-primary);
+    }
+
+    &_link:hover {
+        color: var(--g-color-text-link-hover);
+    }
+}

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
@@ -9,5 +9,12 @@
 
     &__item {
         @include dl-breadcrumbs-items-style;
+
+        &_last,
+        &_last:hover,
+        &_last:active,
+        &_last:visited {
+            color: var(--g-color-text-primary);
+        }
     }
 }

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
@@ -1,3 +1,5 @@
+@import '../../../../styles/mixins.scss';
+
 .dl-collection-breadcrumbs {
     &__skeleton {
         display: block;
@@ -5,19 +7,7 @@
         height: 16px;
     }
 
-    &__item,
-    &__item:visited,
-    &__item:active {
-        color: var(--g-color-text-secondary);
-        display: inline;
-        text-decoration: none;
-
-        &_link:hover {
-            color: var(--g-color-text-link-hover);
-        }
-
-        &:hover {
-            color: var(--g-color-text-primary);
-        }
+    &__item {
+        @include dl-breadcrumbs-items-style;
     }
 }

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
@@ -5,14 +5,19 @@
         height: 16px;
     }
 
-    &__item {
-        color: var(--g-color-text-primary);
+    &__item,
+    &__item:visited,
+    &__item:active {
+        color: var(--g-color-text-secondary);
+        display: inline;
         text-decoration: none;
 
-        &:hover,
-        &:visited,
-        &:active {
-            color: var(--g-color-text-secondary);
+        &_link:hover {
+            color: var(--g-color-text-link-hover);
+        }
+
+        &:hover {
+            color: var(--g-color-text-primary);
         }
     }
 }

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.scss
@@ -11,10 +11,13 @@
         @include dl-breadcrumbs-items-style;
 
         &_last,
-        &_last:hover,
         &_last:active,
         &_last:visited {
             color: var(--g-color-text-primary);
+        }
+
+        &_last:hover {
+            color: var(--g-color-text-link-hover);
         }
     }
 }

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -102,13 +102,9 @@ export const CollectionBreadcrumbs = React.memo<Props>(
                             return <Skeleton className={b('skeleton')} />;
                         }
 
-                        if (isCurrent) {
-                            return item.text;
-                        }
-
                         return (
                             <Link
-                                className={b('item', {link: true})}
+                                className={b('item', {last: isCurrent, link: true})}
                                 to={item.path}
                                 onClick={(e) => {
                                     e.stopPropagation();

--- a/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
+++ b/src/ui/units/collections-navigation/components/CollectionBreadcrumbs/CollectionBreadcrumbs.tsx
@@ -102,9 +102,13 @@ export const CollectionBreadcrumbs = React.memo<Props>(
                             return <Skeleton className={b('skeleton')} />;
                         }
 
+                        if (isCurrent) {
+                            return item.text;
+                        }
+
                         return (
                             <Link
-                                className={b('item', {last: isCurrent})}
+                                className={b('item', {link: true})}
                                 to={item.path}
                                 onClick={(e) => {
                                     e.stopPropagation();


### PR DESCRIPTION
Fix styles (color, margin and fix a broken ellipsis) to make them look like this everywhere:
![2024-04-15_12-40-30](https://github.com/datalens-tech/datalens-ui/assets/56549651/0a164768-46e4-45be-ac45-3c6ee5935c3c)
![2024-04-15_12-47-17](https://github.com/datalens-tech/datalens-ui/assets/56549651/f92ed21f-4a1d-451e-9658-2fd7395a9e24)

 
