### PR TITLE
Add markdown colorify

### DIFF
--- a/src/server/components/charts-engine/components/markdown.ts
+++ b/src/server/components/charts-engine/components/markdown.ts
@@ -8,8 +8,10 @@ import table from '@diplodoc/transform/lib/plugins/table';
 import term from '@diplodoc/transform/lib/plugins/term';
 import {defaultOptions} from '@diplodoc/transform/lib/sanitize';
 import MarkdownIt from 'markdown-it';
-import mila from 'markdown-it-link-attributes';
+import MarkdownItColor from 'markdown-it-color';
+import Mila from 'markdown-it-link-attributes';
 
+import {YFM_COLORIFY_MARKDOWN_CLASSNAME} from '../../../../shared';
 import {registry} from '../../../registry';
 
 export function renderHTML({text = '', lang}: {text: string; lang: string}): {result: string} {
@@ -19,15 +21,19 @@ export function renderHTML({text = '', lang}: {text: string; lang: string}): {re
         cut,
         term,
         (md: MarkdownIt) =>
-            md.use(mila, {
-                matcher(href: string) {
-                    return !href.startsWith('#');
-                },
-                attrs: {
-                    target: '_blank',
-                    rel: 'noopener noreferrer',
-                },
-            }),
+            md
+                .use(Mila, {
+                    matcher(href: string) {
+                        return !href.startsWith('#');
+                    },
+                    attrs: {
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                    },
+                })
+                .use(MarkdownItColor, {
+                    defaultClassName: YFM_COLORIFY_MARKDOWN_CLASSNAME,
+                }),
         imsize,
         table,
         latex({

--- a/src/shared/constants/yfm.ts
+++ b/src/shared/constants/yfm.ts
@@ -1,5 +1,7 @@
 export const MAGICLINK_CLASSNAME = 'magiclinks';
 
+export const YFM_COLORIFY_MARKDOWN_CLASSNAME = 'yfm-colorify';
+
 export const enum YfmQa {
     WrapperHtml = 'yfm-wrapper-html',
 }

--- a/src/ui/components/YfmWrapper/YfmWrapperContent.scss
+++ b/src/ui/components/YfmWrapper/YfmWrapperContent.scss
@@ -138,3 +138,32 @@
         background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+PHBhdGggc3Ryb2tlPSJyZ2JhKDI1NSwgMjU1LCAyNTUsIDAuNykiIGZpbGw9Im5vbmUiIGQ9Ik0zIDZsNSA1IDUtNSI+PC9wYXRoPjwvc3ZnPg==');
     }
 }
+
+.g-root .yfm .yfm-colorify {
+    $colors: (
+        'gray': '--g-color-text-secondary',
+        'yellow': '--g-color-private-yellow-600-solid',
+        'orange': '--g-color-private-orange-500-solid',
+        'red': '--g-color-text-danger',
+        'green': '--g-color-text-positive',
+        'blue': '--g-color-text-info',
+        'violet': '--g-color-text-utility',
+    );
+
+    @each $name, $value in $colors {
+        --yfm-color-text-#{$name}: var(#{$value});
+    }
+
+    // for already colored to black text
+    --yfm-colorify-black: var(--g-color-text-primary);
+
+    @each $name, $value in $colors {
+        --yfm-colorify-#{$name}: var(--yfm-color-text-#{$name});
+    }
+
+    @each $name, $_ in $colors {
+        &.yfm-colorify--#{$name} {
+            color: var(--yfm-colorify-#{$name});
+        }
+    }
+}

--- a/src/ui/components/YfmWrapper/YfmWrapperContent.scss
+++ b/src/ui/components/YfmWrapper/YfmWrapperContent.scss
@@ -142,8 +142,8 @@
 .g-root .yfm .yfm-colorify {
     $colors: (
         'gray': '--g-color-text-secondary',
-        'yellow': '--g-color-private-yellow-600-solid',
-        'orange': '--g-color-private-orange-500-solid',
+        'yellow': '--g-color-text-warning',
+        'orange': '--g-color-text-warning-heavy',
         'red': '--g-color-text-danger',
         'green': '--g-color-text-positive',
         'blue': '--g-color-text-info',


### PR DESCRIPTION
Support colorify for markdown.
Example of usage:
```
{yellow}(text)
```
Supported color names:
- gray
- yellow
- orange
- red
- green
- blue
- violet