### PR TITLE
Fix png images background in yfm

### DIFF
--- a/src/ui/components/YfmWrapper/YfmWrapperContent.scss
+++ b/src/ui/components/YfmWrapper/YfmWrapperContent.scss
@@ -19,7 +19,6 @@
         font-weight: 500;
     }
 
-    .g-root &:not(.yfm_only-light) img,
     img {
         background: transparent;
     }


### PR DESCRIPTION
Before:
<img width="566" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/8a0dc946-5d60-4a9d-ad09-5322beddbda3">

After:
<img width="684" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/15c64af3-a3ce-4c77-b6c4-0777b9be684e">
