### PR TITLE
Fix duplicating filters on diff apply

### DIFF
--- a/src/ui/units/wizard/containers/Wizard/Wizard.tsx
+++ b/src/ui/units/wizard/containers/Wizard/Wizard.tsx
@@ -166,7 +166,7 @@ class Wizard extends React.Component<Props, State> {
                     });
                 },
                 options: {
-                    pathIgnoreList: ['/preview/highchartsWidget'],
+                    pathIgnoreList: ['/preview/highchartsWidget', '/preview/filters'],
                 },
             });
         }


### PR DESCRIPTION
preview.filters and visualization.filters are same object. 

When we include diff from both of these objects, we have correct diff.

<img width="290" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/15093838/985e4a65-2860-4cd3-a890-97991a223ac4">

But when we will apply this diff, we will apply this diff twice to single object.

idea is to exclude preview.filters from diff.