### PR TITLE
Normalize yfm styles

### DIFF
--- a/src/ui/components/DashKit/DashKit.scss
+++ b/src/ui/components/DashKit/DashKit.scss
@@ -1,4 +1,5 @@
 @import '~@gravity-ui/uikit/styles/mixins';
+@import '../../styles/mixins';
 // TODO: think about how to make it more clear (moved these from the dashkit)
 
 .dashkit_theme_datalens {
@@ -25,7 +26,7 @@
         }
 
         div.yfm {
-            @include text-body-2();
+            @include yfm-text-style();
         }
     }
 }

--- a/src/ui/components/DialogParameter/DialogParameter.scss
+++ b/src/ui/components/DialogParameter/DialogParameter.scss
@@ -26,8 +26,9 @@
 
     &__title-tooltip {
         margin-left: 5px;
+
         .yfm {
-            font-size: 13px;
+            @include yfm-text-style();
         }
     }
 

--- a/src/ui/components/YfmWrapper/YfmWrapperContent.scss
+++ b/src/ui/components/YfmWrapper/YfmWrapperContent.scss
@@ -1,4 +1,5 @@
 @import '~@gravity-ui/uikit/styles/mixins';
+@import '../../styles/mixins';
 
 // support yfm dark theme
 
@@ -7,7 +8,7 @@
     --yfm-font-family-monospace: var(--g-font-family-monospace);
 
     font-family: var(--g-font-family-sans);
-    @include text-body-1();
+    @include yfm-text-style();
 
     // override common styles to make it look better with header widgets
     h1,

--- a/src/ui/libs/DatalensChartkit/ChartKit/components/Widget/components/Markdown/Markdown.scss
+++ b/src/ui/libs/DatalensChartkit/ChartKit/components/Widget/components/Markdown/Markdown.scss
@@ -1,10 +1,10 @@
-@import '~@gravity-ui/uikit/styles/mixins';
+@import '../../../../../../../styles/mixins';
 
 .chartkit-markdown {
     overflow: auto;
     padding: 10px;
 
     &.yfm {
-        @include text-body-2();
+        @include yfm-text-style();
     }
 }

--- a/src/ui/styles/mixins.scss
+++ b/src/ui/styles/mixins.scss
@@ -1,4 +1,5 @@
 @import './variables';
+@import '~@gravity-ui/uikit/styles/mixins';
 
 @mixin overflow-ellipsis($type: ellipsis) {
     white-space: nowrap;
@@ -159,4 +160,8 @@
     &_link:hover {
         color: var(--g-color-text-link-hover);
     }
+}
+
+@mixin yfm-text-style {
+    @include text-body-1();
 }


### PR DESCRIPTION
Fixed different font-size:
- on chart:
<img width="105" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/3ef97816-9c05-4d81-95ef-5117900857a5">

- on dash:
<img width="124" alt="image" src="https://github.com/datalens-tech/datalens-ui/assets/98329176/41f1301b-72d7-476f-b8d5-d9ddf3ef1606">
