### PR TITLE
Fix cancellation of request in charts and selectors

### DIFF
--- a/src/ui/components/DashKit/plugins/Control/Control.tsx
+++ b/src/ui/components/DashKit/plugins/Control/Control.tsx
@@ -424,7 +424,7 @@ class Control extends React.PureComponent<PluginControlProps, PluginControlState
 
             const {workbookId} = this.props;
 
-            const payloadCanccelation = chartsDataProvider.getRequestCancellation();
+            const payloadCancellation = chartsDataProvider.getRequestCancellation();
 
             const payload = {
                 data: {
@@ -439,14 +439,14 @@ class Control extends React.PureComponent<PluginControlProps, PluginControlState
                     params: this.actualParams,
                     ...(workbookId ? {workbookId} : {}),
                 },
-                cancelToken: payloadCanccelation.token,
+                cancelToken: payloadCancellation.token,
             };
 
             if (data.sourceType !== DashTabItemControlSourceType.External) {
                 this.cancelCurrentRequests();
             }
 
-            this._cancelSource = payloadCanccelation;
+            this._cancelSource = payloadCancellation;
 
             const response =
                 data.sourceType === DashTabItemControlSourceType.External

--- a/src/ui/components/DashKit/plugins/GroupControl/Control/Control.tsx
+++ b/src/ui/components/DashKit/plugins/GroupControl/Control/Control.tsx
@@ -245,6 +245,8 @@ export const Control = ({
         init();
     };
 
+    // cancel requests, transfer status and remove timer if component is unmounted or selector is
+    // removed from group
     React.useEffect(() => {
         return () => {
             clearLoaderTimer(silentLoaderTimer);

--- a/src/ui/components/DashKit/plugins/GroupControl/Control/Control.tsx
+++ b/src/ui/components/DashKit/plugins/GroupControl/Control/Control.tsx
@@ -391,18 +391,19 @@ export const Control = ({
             source: {elementType},
         } = data as unknown as DashTabItemControlSingle;
 
-        const initialProps = {
+        const stubProps = {
             ...props,
             value: '',
             param: '',
+            onChange: () => {},
         };
         switch (elementType) {
             case DashTabItemControlElementType.Input:
-                return <ControlInput {...initialProps} type="input" />;
+                return <ControlInput {...stubProps} type="input" />;
             case DashTabItemControlElementType.Date:
-                return <ControlDatepicker {...initialProps} type="datepicker" />;
+                return <ControlDatepicker {...stubProps} type="datepicker" />;
             case DashTabItemControlElementType.Checkbox:
-                return <ControlCheckbox {...initialProps} type="checkbox" />;
+                return <ControlCheckbox {...stubProps} type="checkbox" />;
         }
 
         return null;
@@ -425,8 +426,6 @@ export const Control = ({
             style,
             renderOverlay,
             hint: controlData.source.showHint ? controlData.source.hint : undefined,
-
-            onChange: () => {},
         };
 
         if (elementType === DashTabItemControlElementType.Select) {

--- a/src/ui/components/DashKit/plugins/GroupControl/GroupControl.tsx
+++ b/src/ui/components/DashKit/plugins/GroupControl/GroupControl.tsx
@@ -61,7 +61,6 @@ class GroupControl extends React.PureComponent<PluginGroupControlProps, PluginGr
     rootNode: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
     _isUnmounted = false;
-    _cancelSource: any = null;
 
     adjustWidgetLayout = debounce(this.setAdjustWidgetLayout, GROUP_CONTROL_LAYOUT_DEBOUNCE_TIME);
 
@@ -429,7 +428,6 @@ class GroupControl extends React.PureComponent<PluginGroupControlProps, PluginGr
                 getDistincts={getDistincts}
                 onChange={this.onChange}
                 needReload={this.state.needReload}
-                cancelSource={this._cancelSource}
                 workbookId={workbookId}
             />
         );

--- a/src/ui/components/DashKit/plugins/GroupControl/utils.ts
+++ b/src/ui/components/DashKit/plugins/GroupControl/utils.ts
@@ -18,9 +18,3 @@ export const clearLoaderTimer = (timer?: NodeJS.Timeout) => {
         clearTimeout(timer);
     }
 };
-
-export const cancelCurrentRequests = (cancelSource: any) => {
-    if (cancelSource) {
-        cancelSource.cancel('DASHKIT_CONTROL_CANCEL_CURRENT_REQUESTS');
-    }
-};

--- a/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
+++ b/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
@@ -535,7 +535,7 @@ export const useLoadingChart = (props: LoadingChartHookProps) => {
     });
 
     /**
-     * actions before chart unmount
+     * cancel active requests when component is unmounted (changing dash tab, switching to another page)
      */
     React.useEffect(() => {
         return () => {

--- a/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
+++ b/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
@@ -535,6 +535,20 @@ export const useLoadingChart = (props: LoadingChartHookProps) => {
     });
 
     /**
+     * actions before chart unmount
+     */
+    React.useEffect(() => {
+        return () => {
+            for (const requestStatusData of Object.values(requestCancellationRef.current || {})) {
+                if (requestStatusData.requestCancellation) {
+                    requestStatusData.status = 'canceled';
+                    requestStatusData.requestCancellation.cancel();
+                }
+            }
+        };
+    }, []);
+
+    /**
      * force initializing chart loading data, when widget became visible,
      * loading only visible on screen charts
      */

--- a/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
+++ b/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
@@ -319,7 +319,7 @@ export const useLoadingChart = (props: LoadingChartHookProps) => {
      * setting canceling status for any loading requests and cancel them via dataProvider
      */
     const cancelAllLoadingRequests = React.useCallback(
-        (isComponentMounted?: boolean) => {
+        (isComponentMounted: boolean) => {
             for (const [key, requestStatusData] of Object.entries(
                 requestCancellationRef.current || {},
             )) {
@@ -576,7 +576,7 @@ export const useLoadingChart = (props: LoadingChartHookProps) => {
             return;
         }
 
-        cancelAllLoadingRequests();
+        cancelAllLoadingRequests(true);
 
         dispatch({type: WIDGET_CHART_SET_LOADING, payload: true});
 

--- a/src/ui/hooks/useMountedState.ts
+++ b/src/ui/hooks/useMountedState.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function useMountedState(): () => boolean {
+export function useMountedState(deps?: React.DependencyList): () => boolean {
     const mountedRef = React.useRef<boolean>(false);
     const get = React.useCallback(() => mountedRef.current, []);
 
@@ -10,7 +10,7 @@ export function useMountedState(): () => boolean {
         return () => {
             mountedRef.current = false;
         };
-    });
+    }, deps);
 
     return get;
 }

--- a/src/ui/libs/DatalensChartkit/modules/data-provider/charts/index.ts
+++ b/src/ui/libs/DatalensChartkit/modules/data-provider/charts/index.ts
@@ -138,6 +138,8 @@ export interface EntityRequestOptions {
 
 const STATS_COLLECT_TIMEOUT = 5 * 1000;
 
+const CANCEL_REQUEST_CODE = 'REQUEST_CANCELED';
+
 function isResponseSuccessNode(data: ResponseSuccess): data is ResponseSuccessNode {
     return 'type' in data;
 }
@@ -570,7 +572,7 @@ class ChartsDataProvider implements DataProvider<ChartsProps, ChartsData, Cancel
 
     cancelRequests(requestCancellation: CancelTokenSource) {
         if (requestCancellation) {
-            requestCancellation.cancel('REQUEST_CANCELED');
+            requestCancellation.cancel(CANCEL_REQUEST_CODE);
         }
     }
 


### PR DESCRIPTION
- In single and group selectors, requests are canceled if another request is sent.
- Requests for charts and selectors are canceled on unmount.