### PR TITLE
Fixed a bug with sorting by rows in pivot tables

### DIFF
--- a/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
+++ b/src/ui/components/Widgets/Chart/hooks/useLoadingChart.ts
@@ -55,6 +55,7 @@ import type {
     ResolveWidgetDataRef,
     WidgetDataRef,
 } from '../types';
+import {cleanUpConflictingParameters} from '../utils';
 
 import {useIntersectionObserver} from './useIntersectionObserver';
 
@@ -337,6 +338,11 @@ export const useLoadingChart = (props: LoadingChartHookProps) => {
         if (!requestDataProps) {
             return;
         }
+
+        cleanUpConflictingParameters({
+            prev: prevInnerParamsRefCurrent,
+            current: requestDataProps.params,
+        });
 
         // need to prevent double request before get response
         if (changedInnerFlag) {

--- a/src/ui/components/Widgets/Chart/utils.ts
+++ b/src/ui/components/Widgets/Chart/utils.ts
@@ -1,0 +1,21 @@
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
+
+import type {StringParams} from '../../../../shared';
+
+export function cleanUpConflictingParameters(args: {
+    prev: StringParams | undefined | null;
+    current: StringParams | undefined;
+}) {
+    const {prev, current} = args;
+
+    // When changing the parameters, the data in the table may also change,
+    // and the sorting by rows (linked to the data) becomes incorrect.
+    // Therefore, reset the sorting if there are parameters that potentially affect data
+    const tableRowSortKey = '_sortRowMeta';
+    if (prev && current && tableRowSortKey in current) {
+        if (!isEqual(omit(prev, tableRowSortKey), omit(prev, current))) {
+            delete current[tableRowSortKey];
+        }
+    }
+}

--- a/tests/opensource-suites/wizard/visualizations/pivot-table/sorting.test.ts
+++ b/tests/opensource-suites/wizard/visualizations/pivot-table/sorting.test.ts
@@ -1,10 +1,17 @@
 import {expect} from '@playwright/test';
 
-import datalensTest from '../../../../utils/playwright/globalTestDefinition';
-import {openTestPage, slct} from '../../../../utils';
-import {ChartKitQa, WizardPageQa, WizardVisualizationId} from '../../../../../src/shared';
-import WizardPage from '../../../../page-objects/wizard/WizardPage';
+import {
+    ChartKitQa,
+    SectionDatasetQA,
+    WizardPageQa,
+    WizardVisualizationId,
+} from '../../../../../src/shared';
+import {CommonUrls} from '../../../../page-objects/constants/common-urls';
+import {ChartSettingsItems} from '../../../../page-objects/wizard/ChartSettings';
 import {PlaceholderName} from '../../../../page-objects/wizard/SectionVisualization';
+import WizardPage from '../../../../page-objects/wizard/WizardPage';
+import {openTestPage, slct} from '../../../../utils';
+import datalensTest from '../../../../utils/playwright/globalTestDefinition';
 
 datalensTest.describe('Wizard', () => {
     datalensTest.describe('Pivot table', () => {
@@ -14,12 +21,12 @@ datalensTest.describe('Wizard', () => {
 
             await wizardPage.setVisualization(WizardVisualizationId.PivotTable);
 
-            await wizardPage.sectionVisualization.addFieldByClick(PlaceholderName.Filters, 'id');
+            await wizardPage.sectionVisualization.addFieldByClick(PlaceholderName.Filters, 'Id');
             await wizardPage.filterEditor.selectValues(['1', '2']);
             await wizardPage.filterEditor.apply();
 
             const measureField = 'measure';
-            await wizardPage.createNewFieldWithFormula(measureField, 'count([id])');
+            await wizardPage.createNewFieldWithFormula(measureField, 'min([id])');
             await wizardPage.sectionVisualization.addFieldByClick(
                 PlaceholderName.Measures,
                 measureField,
@@ -27,7 +34,7 @@ datalensTest.describe('Wizard', () => {
 
             await wizardPage.sectionVisualization.addFieldByClick(
                 PlaceholderName.PivotTableColumns,
-                'id',
+                'Id',
             );
         });
 
@@ -74,5 +81,58 @@ datalensTest.describe('Wizard', () => {
                 expect(await wizardPage.chartkit.getRowsTexts()).toEqual(initialRowContent);
             },
         );
+
+        datalensTest('Sorting a row by a field with a parameter', async ({page}) => {
+            const parameterName = 'Param';
+            const wizardPage = new WizardPage({page});
+
+            await wizardPage.chartSettings.open();
+            await wizardPage.chartSettings.toggleSettingItem(ChartSettingsItems.Pagination, 'on');
+            await wizardPage.chartSettings.setLimit(1);
+            await wizardPage.chartSettings.apply();
+
+            await wizardPage.createParameter(parameterName, 'City');
+            const fieldFormula = `if([${parameterName}] = 'City', [City], [${parameterName}] = 'Category', [Category], null)`;
+            await wizardPage.createNewFieldWithFormula('ParamField', fieldFormula);
+
+            await wizardPage.sectionVisualization.addFieldByClick(
+                PlaceholderName.Rows,
+                'ParamField',
+            );
+
+            const chartContainer = page.locator(slct(WizardPageQa.SectionPreview));
+            const previewLoader = chartContainer.locator(slct(ChartKitQa.Loader));
+
+            await expect(previewLoader).not.toBeVisible();
+            const firstRow = chartContainer.locator('tbody tr').first();
+            const [[, ...initialRowContent]] = await wizardPage.chartkit.getRowsTexts();
+            let apiRunRequest = wizardPage.page.waitForRequest(
+                (request) => new URL(request.url()).pathname === CommonUrls.ApiRun,
+            );
+            await firstRow.locator('td').first().click();
+            await (await apiRunRequest).response();
+            await expect(previewLoader).not.toBeVisible();
+
+            let [[, ...rowCells]] = await wizardPage.chartkit.getRowsTexts();
+            expect(rowCells).not.toEqual(initialRowContent);
+
+            // Change parameter value
+            apiRunRequest = wizardPage.page.waitForRequest(
+                (request) => new URL(request.url()).pathname === CommonUrls.ApiRun,
+            );
+            const datasetFields = page.locator(slct(SectionDatasetQA.DatasetFields));
+            const parameterLocator = datasetFields.locator(slct(parameterName), {
+                hasText: parameterName,
+            });
+            await parameterLocator.locator(slct(SectionDatasetQA.ItemIcon)).click();
+            await wizardPage.parameterEditor.setDefaultValue('Category');
+            await wizardPage.parameterEditor.apply();
+            await (await apiRunRequest).response();
+            await expect(previewLoader).not.toBeVisible();
+
+            // If the parameter changes, the sorting by rows should be reset
+            [[, ...rowCells]] = await wizardPage.chartkit.getRowsTexts();
+            expect(rowCells).toEqual(initialRowContent);
+        });
     });
 });

--- a/tests/page-objects/wizard/SectionVisualization.ts
+++ b/tests/page-objects/wizard/SectionVisualization.ts
@@ -120,7 +120,8 @@ export default class SectionVisualization {
             force: true,
         });
 
-        await this.page.click(`${slct('select-list')} >> text=${field}`);
+        const selectList = this.page.locator(slct('select-list'));
+        await selectList.getByText(new RegExp(`^${field}$`, 'i')).click();
 
         await promise;
     }


### PR DESCRIPTION
When sorting a pivot table with a column\row with a calculated field by parameter, it returns an error in some cases
