### PR TITLE
Add wrapper to workbook action panel left block

### DIFF
--- a/src/ui/units/workbooks/components/WorkbookPage/hooks/useLayout.tsx
+++ b/src/ui/units/workbooks/components/WorkbookPage/hooks/useLayout.tsx
@@ -71,7 +71,7 @@ export const useLayout = ({workbookId, refreshWorkbookInfo}: UseLayoutArgs) => {
         setLayout({
             actionsPanelLeftBlock: {
                 content: (
-                    <React.Fragment>
+                    <div className={b('action-bar-left-item')}>
                         <ActionPanelEntrySelect />
                         <CollectionBreadcrumbs
                             className={b('breadcrumbs', {'is-mobile': DL.IS_MOBILE})}
@@ -96,7 +96,7 @@ export const useLayout = ({workbookId, refreshWorkbookInfo}: UseLayoutArgs) => {
                                 }
                             }}
                         />
-                    </React.Fragment>
+                    </div>
                 ),
             },
         });


### PR DESCRIPTION
Without this wrapper adding an entry select results in breadcrumbs wrapping over to a new line
the classname already exists in the scss file and is not used anywhere else: https://github.com/datalens-tech/datalens-ui/blob/292d234fcb851bcd5839d20fe53a34768e890133/src/ui/units/workbooks/components/WorkbookPage/WorkbookPage.scss#L47-L51