### PR TITLE
Reduce log messages for DATA_FETCHING_ERROR

### DIFF
--- a/src/server/components/charts-engine/runners/editor.ts
+++ b/src/server/components/charts-engine/runners/editor.ts
@@ -10,6 +10,7 @@ import {getSandboxChartBuilder} from '../components/processor/sandbox-chart-buil
 import {getDuration} from '../components/utils';
 
 import {runServerlessEditor} from './serverlessEditor';
+import {prepareErrorForLogger} from './utils';
 
 import type {RunnerHandlerProps} from '.';
 
@@ -165,7 +166,9 @@ export const runEditor = async (
                             delete resultCopy._confStorageConfig;
                         }
 
-                        cx.log('PROCESSED_WITH_ERRORS', {error: result.error});
+                        const logError = prepareErrorForLogger(result.error);
+
+                        cx.log('PROCESSED_WITH_ERRORS', {error: logError});
 
                         let statusCode = 500;
 

--- a/src/server/components/charts-engine/runners/utils.ts
+++ b/src/server/components/charts-engine/runners/utils.ts
@@ -1,0 +1,42 @@
+import {isObject} from 'lodash';
+
+import {config} from '../constants';
+
+const {DATA_FETCHING_ERROR} = config;
+
+export function prepareErrorForLogger(error: unknown) {
+    if (isObject(error) && 'code' in error && error.code === DATA_FETCHING_ERROR) {
+        let errorDetails = {};
+
+        if (
+            'details' in error &&
+            isObject(error.details) &&
+            'sources' in error.details &&
+            isObject(error.details.sources)
+        ) {
+            const sources = error.details.sources;
+            errorDetails = Object.keys(sources).map((key) => {
+                const source = (sources as Record<string, Record<string, unknown>>)[key];
+                const body = 'body' in source && isObject(source.body) ? source.body : {};
+                return {
+                    [key]: {
+                        sourceType: source.sourceType,
+                        status: source.status,
+                        body: {
+                            message: 'message' in body ? body.message : undefined,
+                            code: 'code' in body ? body.code : undefined,
+                        },
+                    },
+                };
+            });
+        }
+
+        return {
+            code: DATA_FETCHING_ERROR,
+            message: 'message' in error ? error.message : 'Data fetching error',
+            statusCode: 'statusCode' in error ? error.statusCode : undefined,
+            details: errorDetails,
+        };
+    }
+    return error;
+}

--- a/src/server/components/charts-engine/runners/wizard.ts
+++ b/src/server/components/charts-engine/runners/wizard.ts
@@ -9,6 +9,8 @@ import {getWizardChartBuilder} from '../components/processor/worker-chart-builde
 import type {ResolvedConfig} from '../components/storage/types';
 import {getDuration} from '../components/utils';
 
+import {prepareErrorForLogger} from './utils';
+
 import type {RunnerHandler, RunnerHandlerProps} from '.';
 
 export const runWizardChart: RunnerHandler = async (
@@ -192,7 +194,9 @@ export const runWizardChart: RunnerHandler = async (
                                 delete resultCopy._confStorageConfig;
                             }
 
-                            cx.log('PROCESSED_WITH_ERRORS', {error: result.error});
+                            const logError = prepareErrorForLogger(result.error);
+
+                            cx.log('PROCESSED_WITH_ERRORS', {error: logError});
 
                             let statusCode = 500;
 

--- a/src/server/modes/charts/plugins/request-with-dataset/request-dataset.ts
+++ b/src/server/modes/charts/plugins/request-with-dataset/request-dataset.ts
@@ -1,4 +1,5 @@
 import type {Request} from '@gravity-ui/expresskit';
+import {isObject} from 'lodash';
 import isNumber from 'lodash/isNumber';
 
 import type {WorkbookId} from '../../../../../shared';
@@ -56,7 +57,11 @@ export const getDatasetFieldsById = async (
         return response.responseData;
     } catch (err: unknown) {
         if (typeof err === 'object' && err !== null && 'error' in err) {
-            const {error} = err;
+            let {error} = err;
+            if (isObject(error) && 'message' in error) {
+                const message = error.message as string;
+                error = new Error(message);
+            }
             req.ctx.logError('FAILED_TO_RECEIVE_FIELDS', error);
             const status = getStatusFromError(error);
             if (isNumber(status) && status < 500) {


### PR DESCRIPTION
The new "compact" error look's like

```
[21:22:12 UTC] INFO: [Express POST] [chartsRunController] [editorChartRunner] [engineProcessing] PROCESSED_WITH_ERRORS [dl.9a847_ck.5hgv8pzxvt]
    error: {
      "type": "Object",
      "message": "Data fetching error",
      "stack":
          
      "code": "ERR.CHARTS.DATA_FETCHING_ERROR",
      "statusCode": 427,
      "details": [
        {
          "qvnkqz8s0wdqf_resulte45d1c70-34d1-11ed-817f-4bf0db94f173": {
            "sourceType": "bi_datasets",
            "status": 400,
            "body": {
              "message": "Data source host name or service not known.",
              "code": "ERR.DS_API.DB.SOURCE_HOST_NOT_KNOWN_ERROR"
            }
          }
        },
        {
          "qvnkqz8s0wdqf_resultc7472090-34d1-11ed-817f-4bf0db94f173": {
            "sourceType": "bi_datasets",
            "status": 400,
            "body": {
              "message": "Data source host name or service not known.",
              "code": "ERR.DS_API.DB.SOURCE_HOST_NOT_KNOWN_ERROR"
            }
          }
        }
      ]
    }
```