### PR TITLE
Block clicks around checkboxes in collections 

### DIFF
--- a/src/ui/units/collections/components/CollectionContentTable/TableComponents/CollectionCheckboxCell.tsx
+++ b/src/ui/units/collections/components/CollectionContentTable/TableComponents/CollectionCheckboxCell.tsx
@@ -32,12 +32,23 @@ export const CollectionCheckboxCell = ({
         });
     };
 
+    const onCheckboxContainerClick = React.useCallback(
+        (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+            if (!canMoveItem) return;
+            if (event.target === event.currentTarget) {
+                event.preventDefault();
+            }
+            event.stopPropagation();
+        },
+        [canMoveItem],
+    );
+
     return (
         <div
             className={b('content-cell', {
                 disabled: !canMoveItem,
             })}
-            onClick={(e) => e.stopPropagation()}
+            onClick={onCheckboxContainerClick}
         >
             <Checkbox
                 size="l"


### PR DESCRIPTION
to prevent unexpected navigation into collection item

