### PR TITLE
Replace convertConnectionType with another function in registry(QL)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,14 +8,14 @@ import {getAppEndpointsConfig} from '../shared/endpoints';
 import {appEnv} from './app-env';
 import {getOpensourceLayoutConfig} from './components/layout/opensource-layout-config';
 import authZitadel from './middlewares/auth-zitadel';
-import {convertConnectionType} from './modes/charts/plugins/ql/utils/connection';
+import {getConnectorToQlConnectionTypeMap} from './modes/charts/plugins/ql/utils/connection';
 import initOpensourceApp from './modes/opensource/app';
 import {nodekit} from './nodekit';
 import {registry} from './registry';
 import {registerAppPlugins} from './registry/utils/register-app-plugins';
 
 registry.registerGetLayoutConfig(getOpensourceLayoutConfig);
-registry.registerConvertConnectorTypeToQLConnectionType(convertConnectionType);
+registry.setupQLConnectionTypeMap(getConnectorToQlConnectionTypeMap());
 
 registerAppPlugins();
 

--- a/src/server/modes/charts/plugins/ql/module/js/build-graph.ts
+++ b/src/server/modes/charts/plugins/ql/module/js/build-graph.ts
@@ -21,6 +21,7 @@ import {mapQlConfigToLatestVersion} from '../../../../../../../shared/modules/co
 import prepareSingleResult from '../../../datalens/js/helpers/misc/prepare-single-result';
 import {extractColorPalettesFromData} from '../../../helpers/color-palettes';
 import {getFieldList} from '../../../helpers/misc';
+import type {QLConnectionTypeMap} from '../../utils/connection';
 import {
     doesQueryContainOrderBy,
     getColumnsAndRows,
@@ -46,10 +47,12 @@ type BuildGraphArgs = {
     ChartEditor: IChartEditor;
     features: FeatureConfig;
     palettes: Record<string, Palette>;
+    qlConnectionTypeMap: QLConnectionTypeMap;
 };
 
 // eslint-disable-next-line complexity
-export function buildGraph({shared, ChartEditor, features, palettes}: BuildGraphArgs) {
+export function buildGraph(args: BuildGraphArgs) {
+    const {shared, ChartEditor, features, palettes, qlConnectionTypeMap} = args;
     const data = ChartEditor.getLoadedData();
 
     log('LOADED DATA:', data);
@@ -67,6 +70,7 @@ export function buildGraph({shared, ChartEditor, features, palettes}: BuildGraph
         queries: config.queries,
         connectionType: config.connection.type,
         data: loadedData,
+        qlConnectionTypeMap,
     });
 
     if (

--- a/src/server/modes/charts/plugins/ql/module/js/index.ts
+++ b/src/server/modes/charts/plugins/ql/module/js/index.ts
@@ -9,6 +9,7 @@ export default ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEdi
     const features = getServerFeatures(app.nodekit.ctx);
     const {getAvailablePalettesMap} = registry.common.functions.getAll();
     const palettes = getAvailablePalettesMap();
+    const qlConnectionTypeMap = registry.getQLConnectionTypeMap();
 
-    return buildGraph({shared, ChartEditor, features, palettes});
+    return buildGraph({shared, ChartEditor, features, palettes, qlConnectionTypeMap});
 };

--- a/src/server/modes/charts/plugins/ql/module/url/build-sources.ts
+++ b/src/server/modes/charts/plugins/ql/module/url/build-sources.ts
@@ -39,7 +39,7 @@ const prepareDefaultDate = (date: string) => {
 };
 
 export function buildSources(args: BuildSourcesArgs) {
-    const {shared, ChartEditor, palettes} = args;
+    const {shared, ChartEditor, palettes, qlConnectionTypeMap} = args;
     const config = mapQlConfigToLatestVersion(shared, {i18n: ChartEditor.getTranslation});
 
     const urlParams = ChartEditor.getParams();
@@ -190,6 +190,7 @@ export function buildSources(args: BuildSourcesArgs) {
 
                         params: localParams,
                         paramsDescription: localParamsDescription,
+                        qlConnectionTypeMap,
                     });
 
                     sources[`ql_${i}`] = source;
@@ -208,6 +209,7 @@ export function buildSources(args: BuildSourcesArgs) {
 
                     params,
                     paramsDescription: config.params,
+                    qlConnectionTypeMap,
                 }),
             };
         }

--- a/src/server/modes/charts/plugins/ql/module/url/index.ts
+++ b/src/server/modes/charts/plugins/ql/module/url/index.ts
@@ -6,6 +6,7 @@ import {buildSources} from './build-sources';
 export default function ({shared, ChartEditor}: {shared: QlConfig; ChartEditor: IChartEditor}) {
     const {getAvailablePalettesMap} = registry.common.functions.getAll();
     const palettes = getAvailablePalettesMap();
+    const qlConnectionTypeMap = registry.getQLConnectionTypeMap();
 
-    return buildSources({shared, ChartEditor, palettes});
+    return buildSources({shared, ChartEditor, palettes, qlConnectionTypeMap});
 }

--- a/src/server/modes/charts/plugins/ql/module/url/types.ts
+++ b/src/server/modes/charts/plugins/ql/module/url/types.ts
@@ -1,7 +1,9 @@
 import type {IChartEditor, Palette, QlConfig} from '../../../../../../../shared';
+import type {QLConnectionTypeMap} from '../../utils/connection';
 
 export type BuildSourcesArgs = {
     shared: QlConfig;
     ChartEditor: IChartEditor;
     palettes: Record<string, Palette>;
+    qlConnectionTypeMap: QLConnectionTypeMap;
 };

--- a/src/server/modes/charts/plugins/ql/ql-chart-runner.ts
+++ b/src/server/modes/charts/plugins/ql/ql-chart-runner.ts
@@ -11,12 +11,20 @@ import type {WizardWorker} from '../../../../components/charts-engine/components
 import type {RunnerHandler, RunnerHandlerProps} from '../../../../components/charts-engine/runners';
 import {runChart} from '../../../../components/charts-engine/runners/chart';
 import {runWorkerChart} from '../../../../components/charts-engine/runners/worker';
+import {registry} from '../../../../registry';
+
+import type {QLAdditionalData} from './types';
 
 let wizardWorkersPool: Pool | null = null;
 async function getQlWorker(): Promise<Proxy<WizardWorker>> {
     if (wizardWorkersPool === null) {
         const scriptPath = path.resolve(__dirname, './worker');
-        wizardWorkersPool = workerpool.pool(scriptPath);
+        const additionalData: QLAdditionalData = {
+            qlConnectionTypeMap: registry.getQLConnectionTypeMap(),
+        };
+        wizardWorkersPool = workerpool.pool(scriptPath, {
+            workerThreadOpts: {workerData: additionalData},
+        });
     }
 
     return wizardWorkersPool.proxy<WizardWorker>();

--- a/src/server/modes/charts/plugins/ql/types.ts
+++ b/src/server/modes/charts/plugins/ql/types.ts
@@ -1,0 +1,5 @@
+import type {QLConnectionTypeMap} from './utils/connection';
+
+export type QLAdditionalData = {
+    qlConnectionTypeMap: QLConnectionTypeMap;
+};

--- a/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
+++ b/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
@@ -4,15 +4,19 @@ import {buildSource, doesQueryContainOrderBy, iterateThroughVisibleQueries} from
 
 const MOCK_ID = 'MOCK_ID';
 
-const mockedBuildSourceArgsSet = {
+const commonBuildSourceArgsSet = {
     id: MOCK_ID,
     connectionType: 'postgres',
+    qlConnectionTypeMap: {postgres: 'postgres'},
+};
+
+const mockedBuildSourceArgsSet = {
+    ...commonBuildSourceArgsSet,
     query: 'select built_year, iznos from public.sample where built_year in {{years}} limit 10',
     params: {years: '1995'},
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
-    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultSet = {
@@ -26,14 +30,12 @@ const expectedBuildSourceResultSet = {
 };
 
 const mockedBuildSourceArgsSingle = {
-    id: MOCK_ID,
-    connectionType: 'postgres',
+    ...commonBuildSourceArgsSet,
     query: 'select built_year, iznos from public.sample where built_year = {{years}} limit 10',
     params: {years: '1995'},
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
-    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultSingle = {
@@ -47,14 +49,12 @@ const expectedBuildSourceResultSingle = {
 };
 
 const mockedBuildSourceArgsPrewrapped = {
-    id: MOCK_ID,
-    connectionType: 'postgres',
+    ...commonBuildSourceArgsSet,
     query: 'select built_year, iznos from public.sample where built_year in ({{years}}) limit 10',
     params: {years: '1995'},
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
-    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultPrewrapped = {

--- a/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
+++ b/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
@@ -1,4 +1,5 @@
 import type {QLConfigQuery} from '../../../../../../../shared';
+import {ConnectorType} from '../../../../../../../shared';
 import {convertConnectionType} from '../connection';
 import {buildSource, doesQueryContainOrderBy, iterateThroughVisibleQueries} from '../misc-helpers';
 
@@ -7,7 +8,7 @@ const MOCK_ID = 'MOCK_ID';
 const commonBuildSourceArgsSet = {
     id: MOCK_ID,
     connectionType: 'postgres',
-    qlConnectionTypeMap: {postgres: 'postgres'},
+    qlConnectionTypeMap: {postgres: ConnectorType.Postgres},
 };
 
 const mockedBuildSourceArgsSet = {

--- a/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
+++ b/src/server/modes/charts/plugins/ql/utils/__tests__/misc-helpers.test.ts
@@ -12,6 +12,7 @@ const mockedBuildSourceArgsSet = {
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
+    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultSet = {
@@ -32,6 +33,7 @@ const mockedBuildSourceArgsSingle = {
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
+    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultSingle = {
@@ -52,6 +54,7 @@ const mockedBuildSourceArgsPrewrapped = {
     paramsDescription: [
         {type: 'string', name: 'years', defaultValue: ['1990', '1995'], overridenValue: '1995'},
     ],
+    qlConnectionTypeMap: {},
 };
 
 const expectedBuildSourceResultPrewrapped = {

--- a/src/server/modes/charts/plugins/ql/utils/connection.ts
+++ b/src/server/modes/charts/plugins/ql/utils/connection.ts
@@ -19,8 +19,17 @@ export const CONNECTOR_TYPE_TO_QL_CONNECTION_TYPE_MAP: Record<string, ConnectorT
     [ConnectorType.MonitoringExt]: DATALENS_QL_CONNECTION_TYPES.MONITORING,
 };
 
-export function convertConnectionType(connectionType: string) {
-    const mappedConnectionType = CONNECTOR_TYPE_TO_QL_CONNECTION_TYPE_MAP[connectionType];
+export function getConnectorToQlConnectionTypeMap() {
+    return CONNECTOR_TYPE_TO_QL_CONNECTION_TYPE_MAP;
+}
+
+export type QLConnectionTypeMap = ReturnType<typeof getConnectorToQlConnectionTypeMap>;
+
+export function convertConnectionType(
+    connectionTypeMap: QLConnectionTypeMap,
+    connectionType: string,
+) {
+    const mappedConnectionType = connectionTypeMap[connectionType];
 
     if (!mappedConnectionType) {
         throw new Error('Unsupported connection type');

--- a/src/server/modes/charts/plugins/ql/worker.ts
+++ b/src/server/modes/charts/plugins/ql/worker.ts
@@ -1,3 +1,5 @@
+import {workerData} from 'worker_threads';
+
 import workerPool from 'workerpool';
 
 import type {QlConfig, QlExtendedConfig} from '../../../../../shared';
@@ -17,7 +19,14 @@ import {getChartApiContext} from '../../../../components/charts-engine/component
 import {createI18nInstance} from '../../../../utils/language';
 
 import qlModule from './module/private-module';
+import type {QLAdditionalData} from './types';
 import {identifyParams} from './utils/identify-params';
+
+function getQLAdditionalData(): QLAdditionalData {
+    return {
+        qlConnectionTypeMap: workerData?.qlConnectionTypeMap ?? {},
+    };
+}
 
 const worker: WizardWorker = {
     buildParams: async (args: BuildParamsArgs) => {
@@ -48,11 +57,13 @@ const worker: WizardWorker = {
         const console = new Console({});
         qlModule.setConsole(console);
 
+        const {qlConnectionTypeMap} = getQLAdditionalData();
         return {
             exports: qlModule.buildSources({
                 shared: shared as QlConfig,
                 ChartEditor: context.ChartEditor,
                 palettes,
+                qlConnectionTypeMap,
             }),
             runtimeMetadata: context.__runtimeMetadata,
             logs: console.getLogs(),
@@ -144,11 +155,13 @@ const worker: WizardWorker = {
         const console = new Console({});
         qlModule.setConsole(console);
 
+        const {qlConnectionTypeMap} = getQLAdditionalData();
         const result = qlModule.buildGraph({
             shared: shared as QlConfig,
             ChartEditor: context.ChartEditor,
             palettes,
             features,
+            qlConnectionTypeMap,
         });
 
         return {

--- a/src/server/registry/index.ts
+++ b/src/server/registry/index.ts
@@ -5,9 +5,9 @@ import getGatewayControllers from '@gravity-ui/gateway';
 import type {AppContext} from '@gravity-ui/nodekit';
 
 import type {ChartsEngine} from '../components/charts-engine';
-import {convertConnectionType} from '../modes/charts/plugins/ql/utils/connection';
+import type {QLConnectionTypeMap} from '../modes/charts/plugins/ql/utils/connection';
+import {getConnectorToQlConnectionTypeMap} from '../modes/charts/plugins/ql/utils/connection';
 import type {GetLayoutConfig} from '../types/app-layout';
-import type {ConvertConnectorTypeToQLConnectionType} from '../types/connections';
 import type {XlsxConverterFn} from '../types/xlsxConverter';
 
 import commonRegistry from './units/common';
@@ -24,7 +24,7 @@ let gateway: ReturnType<typeof wrapperGetGatewayControllers>;
 let getLayoutConfig: GetLayoutConfig | undefined;
 let yfmPlugins: MarkdownItPluginCb[];
 let getXlsxConverter: XlsxConverterFn | undefined;
-let convertConnectorTypeToQLConnectionType: ConvertConnectorTypeToQLConnectionType | undefined;
+let qLConnectionTypeMap: QLConnectionTypeMap | undefined;
 
 export const registry = {
     common: commonRegistry,
@@ -109,15 +109,12 @@ export const registry = {
     getXlsxConverter() {
         return getXlsxConverter;
     },
-    registerConvertConnectorTypeToQLConnectionType(fn: ConvertConnectorTypeToQLConnectionType) {
-        if (!convertConnectorTypeToQLConnectionType) {
-            convertConnectorTypeToQLConnectionType = fn;
+    setupQLConnectionTypeMap(map: QLConnectionTypeMap) {
+        if (!qLConnectionTypeMap) {
+            qLConnectionTypeMap = map;
         }
     },
-    getConvertConnectorTypeToQLConnectionType() {
-        if (!convertConnectorTypeToQLConnectionType) {
-            return convertConnectionType;
-        }
-        return convertConnectorTypeToQLConnectionType;
+    getQLConnectionTypeMap() {
+        return qLConnectionTypeMap ?? getConnectorToQlConnectionTypeMap();
     },
 };


### PR DESCRIPTION
before:

```js
const QLExtendedType = {
  ...generalTypes,
  myConnector: MyConnectionType
};
function customFunctionWithQLExtendedTypes(type) {
  return QLExtendedType[type];
}
registry.registerConvertConnectorTypeToQLConnectionType(convertConnectionType);
```

after:

```js
const QLExtendedType = {
  ...generalTypes,
  myConnector: MyConnectionType
};
registry.setupQLConnectionTypeMap(QLExtendedType);
```