### PR TITLE
Fixed navigation dialog width

### DIFF
--- a/src/ui/components/Navigation/Core/NavigationModal.scss
+++ b/src/ui/components/Navigation/Core/NavigationModal.scss
@@ -2,9 +2,8 @@
     $_: &;
 
     &_modal {
-        width: 90vw;
         height: 90vh;
-        max-width: 1024px;
+        width: 1024px;
         overflow: hidden;
     }
 


### PR DESCRIPTION
**Before (without scroll)**
<img width="581" alt="Screenshot 2024-10-01 at 11 00 07" src="https://github.com/user-attachments/assets/0ea65163-9e66-45cf-8f41-dfc31293c082">

**After (with scroll)**
<img width="596" alt="Screenshot 2024-10-01 at 11 01 33" src="https://github.com/user-attachments/assets/da110aa1-c2b1-4d12-8319-df2625a6470d">
