### PR TITLE
Clean sass deprecation warnings

### DIFF
--- a/src/ui/components/AsideHeaderAdapter/AsideHeaderAdapter.scss
+++ b/src/ui/components/AsideHeaderAdapter/AsideHeaderAdapter.scss
@@ -3,10 +3,12 @@
 .dl-aside-header {
     &__item-link {
         @include link-reset;
-        display: flex;
-        height: 40px;
-        width: 100%;
-        align-items: center;
+        & {
+            display: flex;
+            height: 40px;
+            width: 100%;
+            align-items: center;
+        }
     }
 
     &__item-wrap {

--- a/src/ui/components/DashKit/plugins/GroupControl/GroupControl.scss
+++ b/src/ui/components/DashKit/plugins/GroupControl/GroupControl.scss
@@ -7,8 +7,8 @@
 
     $itemsRightPadding: 10px;
 
-    $buttonVerticalPaddings: ($controlDefaultHeight - $buttonSmallHeight)/2;
-    $checkboxVerticalPaddings: ($controlDefaultHeight - $checkboxHeight)/2;
+    $buttonVerticalPaddings: ($controlDefaultHeight - $buttonSmallHeight) * 0.5;
+    $checkboxVerticalPaddings: ($controlDefaultHeight - $checkboxHeight) * 0.5;
 
     display: block;
     height: 100%;

--- a/src/ui/components/DialogChartWidget/DialogChartWidget.scss
+++ b/src/ui/components/DialogChartWidget/DialogChartWidget.scss
@@ -13,7 +13,9 @@
         width: 705px;
     }
 
-    --dl-dropdown-navigation-width: 330px;
+    & {
+        --dl-dropdown-navigation-width: 330px;
+    }
 
     &__sidebar {
         max-height: 100%;

--- a/src/ui/components/Navigation/Core/TableView/TableView.scss
+++ b/src/ui/components/Navigation/Core/TableView/TableView.scss
@@ -222,7 +222,9 @@
             background: var(--g-color-base-simple-hover);
         }
 
-        color: var(--g-color-text-secondary);
+        & {
+            color: var(--g-color-text-secondary);
+        }
     }
 
     &__btn-change-favorite {

--- a/src/ui/libs/DatalensChartkit/components/Control/Control.scss
+++ b/src/ui/libs/DatalensChartkit/components/Control/Control.scss
@@ -56,11 +56,11 @@
 
         // TODO: move styles to Items.scss after removing old selectors code
         &_button {
-            padding: ($controlDefaultHeight - $buttonSmallHeight)/2 0;
+            padding: ($controlDefaultHeight - $buttonSmallHeight) * 0.5 0;
         }
 
         &_checkbox {
-            padding: ($controlDefaultHeight - $checkboxHeight)/2 0;
+            padding: ($controlDefaultHeight - $checkboxHeight) * 0.5 0;
         }
 
         &:not(:last-child) {

--- a/src/ui/styles/mixins.scss
+++ b/src/ui/styles/mixins.scss
@@ -149,9 +149,10 @@
     &:active {
         color: var(--g-color-text-secondary);
     }
-
-    display: inline;
-    text-decoration: none;
+    & {
+        display: inline;
+        text-decoration: none;
+    }
 
     &:hover {
         color: var(--g-color-text-primary);

--- a/src/ui/units/dash/containers/Body/Body.scss
+++ b/src/ui/units/dash/containers/Body/Body.scss
@@ -80,14 +80,16 @@ $actionPanelDefaultBottom: 20px;
             overflow: hidden;
         }
 
-        border-right: var(--dl-dash-select-container-border-right-width) solid
-            var(--dl-dash-select-container-border-color);
-        border-left: var(--dl-dash-select-container-border-left-width) solid
-            var(--dl-dash-select-container-border-color);
-        border-bottom: var(--dl-dash-select-container-border-bottom-width) solid
-            var(--dl-dash-select-container-border-color);
-        border-top: var(--dl-dash-select-container-border-top-width) solid
-            var(--dl-dash-select-container-border-color);
+        & {
+            border-right: var(--dl-dash-select-container-border-right-width) solid
+                var(--dl-dash-select-container-border-color);
+            border-left: var(--dl-dash-select-container-border-left-width) solid
+                var(--dl-dash-select-container-border-color);
+            border-bottom: var(--dl-dash-select-container-border-bottom-width) solid
+                var(--dl-dash-select-container-border-color);
+            border-top: var(--dl-dash-select-container-border-top-width) solid
+                var(--dl-dash-select-container-border-color);
+        }
     }
 
     &__content-container {

--- a/src/ui/units/dash/containers/FixedHeader/FixedHeader.scss
+++ b/src/ui/units/dash/containers/FixedHeader/FixedHeader.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @mixin flexReactGridLayout($minHeight: 44px) {
     & > .react-grid-layout {
         flex: 1;
@@ -56,7 +58,7 @@ $fixedSectionOffset: 8px;
     }
 
     &__controls-settings {
-        width: (100% / 36) * 1;
+        width: math.div(100%, 36) * 1;
         flex-shrink: 0;
         position: relative;
     }


### PR DESCRIPTION
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls


Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($controlDefaultHeight - $buttonSmallHeight, 2) or calc(($controlDefaultHeight - $buttonSmallHeight) / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div