### PR TITLE
Remove chartkitDefault useless endpoint

### DIFF
--- a/src/ui/libs/DatalensChartkit/modules/data-provider/charts/index.ts
+++ b/src/ui/libs/DatalensChartkit/modules/data-provider/charts/index.ts
@@ -530,7 +530,7 @@ class ChartsDataProvider implements DataProvider<ChartsProps, ChartsData, Cancel
     }
 
     private settings: Settings = {
-        endpoint: DL.ENDPOINTS.chartkitDefault,
+        endpoint: '/',
         lang: 'ru',
         noRetry: false,
     };


### PR DESCRIPTION
Always override at
https://github.com/datalens-tech/datalens-ui/blob/main/src/ui/libs/DatalensChartkit/ChartKit/init.ts#L44