### PR TITLE
Fix add chart to dashboard options overflow

### DIFF
--- a/src/ui/components/WorkbookNavigationMinimal/WorkbookNavigationMinimal.scss
+++ b/src/ui/components/WorkbookNavigationMinimal/WorkbookNavigationMinimal.scss
@@ -1,3 +1,5 @@
+@import '~@gravity-ui/uikit/styles/mixins';
+
 .dl-core-workbook-navigation-minimal {
     width: 416px;
     height: 540px;
@@ -25,6 +27,7 @@
         padding-right: 0;
         display: flex;
         width: 100%;
+        overflow: hidden;
     }
 
     &__popup {
@@ -47,6 +50,10 @@
         overflow: hidden;
         min-width: 100px;
         color: var(--g-color-text-primary);
+
+        span {
+            @include overflow-ellipsis();
+        }
     }
 
     &__name-line {


### PR DESCRIPTION
<img width="626" alt="Screenshot 2024-11-15 at 23 32 51" src="https://github.com/user-attachments/assets/f42d2762-e5e1-4de6-ad3f-77969d3c6c24">

<img width="484" alt="Screenshot 2024-11-15 at 23 32 37" src="https://github.com/user-attachments/assets/55995d91-6b32-490e-b91f-8d573c1fc0fb">
