### PR TITLE
Fix KeyValue form component

### DIFF
--- a/src/ui/components/ConnectorIcon/ConnectorIcon.tsx
+++ b/src/ui/components/ConnectorIcon/ConnectorIcon.tsx
@@ -6,6 +6,8 @@ import block from 'bem-cn-lite';
 import isObject from 'lodash/isObject';
 import type {ConnectorIconData, ConnectorIconView} from 'shared/schema/types';
 
+import iconUndefined from 'ui/assets/icons/connections/undefined.svg';
+
 import './ConnectorIcon.scss';
 
 const b = block('dl-connector-icon');
@@ -35,7 +37,20 @@ type BIConnectorIconProps = Pick<IconProps, 'className' | 'height' | 'width' | '
 const BIConnectorIcon = (props: BIConnectorIconProps) => {
     const {data, className, height, width, qa, view = 'standard'} = props;
     const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState(false);
     const src = ('data' in data ? data.data : data.url)[view];
+
+    if (error) {
+        return (
+            <Icon
+                className={className}
+                data={iconUndefined}
+                height={height}
+                width={width}
+                qa={qa}
+            />
+        );
+    }
 
     return (
         <React.Fragment>
@@ -46,6 +61,7 @@ const BIConnectorIcon = (props: BIConnectorIconProps) => {
                 width={width}
                 src={src}
                 onLoad={loading ? () => setLoading(false) : undefined}
+                onError={() => setError(true)}
             />
             {loading && <Skeleton className={className} style={{width, height}} />}
         </React.Fragment>

--- a/src/ui/units/connections/components/ConnectorForm/components/KeyValue/KeyValue.tsx
+++ b/src/ui/units/connections/components/ConnectorForm/components/KeyValue/KeyValue.tsx
@@ -30,10 +30,6 @@ const KeyValueEntryView = (props: KeyValueEntryViewProps) => {
         placeholder = i18n('label_secret-value');
     }
 
-    if (entry.value === null) {
-        return null;
-    }
-
     return (
         <div className={b('entry')}>
             <Select
@@ -51,7 +47,7 @@ const KeyValueEntryView = (props: KeyValueEntryViewProps) => {
                 <PasswordInput
                     {...valueInputProps}
                     className={b('value-input')}
-                    value={entry.value}
+                    value={entry.value || ''}
                     hideCopyButton={true}
                     placeholder={placeholder}
                     onUpdate={(value) => {
@@ -62,7 +58,7 @@ const KeyValueEntryView = (props: KeyValueEntryViewProps) => {
                 <TextInput
                     {...valueInputProps}
                     className={b('value-input')}
-                    value={entry.value}
+                    value={entry.value || ''}
                     onUpdate={(value) => {
                         onUpdate(index, {value});
                     }}

--- a/src/ui/units/connections/components/ConnectorForm/components/KeyValue/hooks.ts
+++ b/src/ui/units/connections/components/ConnectorForm/components/KeyValue/hooks.ts
@@ -27,15 +27,12 @@ const initialEntriesToKeyValues = (entries: KeyValueResult['entries'] = {}): Key
 };
 
 const keyValuesToEntries = (keyValues: KeyValueEntry[] = []): KeyValueResult['entries'] => {
-    return keyValues.reduce<KeyValueResult['entries']>(
-        (acc, {key, value, error, initial, touched}) => {
-            if (key && !error && (!initial || (initial && touched))) {
-                acc[key] = value;
-            }
-            return acc;
-        },
-        {},
-    );
+    return keyValues.reduce<KeyValueResult['entries']>((acc, {key, value, error}) => {
+        if (key && !error) {
+            acc[key] = value;
+        }
+        return acc;
+    }, {});
 };
 
 const getValidatedKeyValues = (keyValues: KeyValueEntry[]) => {
@@ -124,20 +121,15 @@ export function useKeyValueState(props: {
         nextKeyValues[index] = {
             ...updatedKeyValue,
             ...updates,
-            touched: true,
         };
         updateKeyValues(nextKeyValues);
     };
 
     const handleDeleteKeyValue = (index: number) => {
         const deletedItem = keyValues[index];
-        const nextKeyValues: KeyValueEntry[] = deletedItem.initial
-            ? [
-                  ...keyValues.slice(0, index),
-                  {key: deletedItem.key, value: null},
-                  ...keyValues.slice(index + 1),
-              ]
-            : [...keyValues.slice(0, index), ...keyValues.slice(index + 1)];
+        const nextKeyValues = keyValues.filter((entry) => {
+            return !(entry.key === deletedItem.key && entry.value === deletedItem.value);
+        });
         updateKeyValues(nextKeyValues);
     };
 

--- a/src/ui/units/connections/components/ConnectorForm/components/KeyValue/types.ts
+++ b/src/ui/units/connections/components/ConnectorForm/components/KeyValue/types.ts
@@ -7,5 +7,4 @@ export type KeyValueEntry = {
     value: string | null;
     error?: 'duplicated-key';
     initial?: boolean;
-    touched?: boolean;
 };


### PR DESCRIPTION
### Features:
We've decided to change the logic of this component `CHARTS-10647#679a078fb60d584e88964bc1`:
- If the header value has been changed, the changed value is sent.
- If nothing has changed in the header, then we return the pair unchanged to the back, i.e. the same null (or an empty string) is sent back to the value
- If the header has been deleted, then nothing is sent to the backup, i.e. the entire pair (key, value) is deleted from the list
### Fixes:
- fix `BIConnectorIcon` for cases when image resource does not existing