### PR TITLE
Delete client stacktrace from the error details

### DIFF
--- a/src/ui/components/DialogErrorWithTabs/DialogErrorWithTabs.scss
+++ b/src/ui/components/DialogErrorWithTabs/DialogErrorWithTabs.scss
@@ -12,7 +12,7 @@
     &__content {
         width: $contentDesktopMaxWidth;
         max-height: 80vh;
-        height: 500px;
+        height: 400px;
         display: flex;
         flex-direction: column;
 

--- a/src/ui/components/DialogErrorWithTabs/Tabs/DebugTab/DebugTab.tsx
+++ b/src/ui/components/DialogErrorWithTabs/Tabs/DebugTab/DebugTab.tsx
@@ -40,12 +40,9 @@ const DebugTab: React.FC<Props> = ({error}: Props) => {
         }
     });
 
-    const trace =
-        'stackTrace' in errorDetails ? JSON.stringify(errorDetails.stackTrace, null, 4) : '';
+    const errorMessage = errorContent.join('\n\n');
 
-    const errorMessage = errorContent.join('\n');
-
-    return <ErrorText errorMessage={errorMessage} errorExtraDetails={trace} />;
+    return <ErrorText errorMessage={errorMessage} />;
 };
 
 export default DebugTab;

--- a/src/ui/components/DialogErrorWithTabs/Tabs/DebugTab/DebugTab.tsx
+++ b/src/ui/components/DialogErrorWithTabs/Tabs/DebugTab/DebugTab.tsx
@@ -40,7 +40,8 @@ const DebugTab: React.FC<Props> = ({error}: Props) => {
         }
     });
 
-    const trace = 'stack' in error ? JSON.stringify(error.stack, null, 4) : '';
+    const trace =
+        'stackTrace' in errorDetails ? JSON.stringify(errorDetails.stackTrace, null, 4) : '';
 
     const errorMessage = errorContent.join('\n');
 


### PR DESCRIPTION
Can we delete client stacktrace? Maybe I missed smth?

Before
<img width="400" alt="Screenshot 2025-03-07 at 21 45 14" src="https://github.com/user-attachments/assets/2615a7b8-fd37-44a2-9a7c-e3a68de9e949" />


After
<img width="400" alt="Screenshot 2025-03-07 at 21 48 37" src="https://github.com/user-attachments/assets/2379a731-e6df-47b9-92de-58610b9bf960" />


