### PR TITLE
Fix for unnamed contoller

### DIFF
--- a/src/server/controllers/api.ts
+++ b/src/server/controllers/api.ts
@@ -5,7 +5,7 @@ import {registry} from '../registry';
 import type {DatalensGatewaySchemas} from '../types/gateway';
 import type {GatewayApiErrorResponse} from '../utils/gateway';
 
-export const apiContollers = {
+export const apiControllers = {
     deleteLock: async (req: Request, res: Response) => {
         try {
             const {entryId, params} = req.body;

--- a/src/server/controllers/api.ts
+++ b/src/server/controllers/api.ts
@@ -5,7 +5,7 @@ import {registry} from '../registry';
 import type {DatalensGatewaySchemas} from '../types/gateway';
 import type {GatewayApiErrorResponse} from '../utils/gateway';
 
-export default {
+export const apiContollers = {
     deleteLock: async (req: Request, res: Response) => {
         try {
             const {entryId, params} = req.body;

--- a/src/server/controllers/dl-main.ts
+++ b/src/server/controllers/dl-main.ts
@@ -2,7 +2,7 @@ import type {Request, Response} from '@gravity-ui/expresskit';
 
 import {registry} from '../registry';
 
-export default async (req: Request, res: Response) => {
+export const dlMainController = async (req: Request, res: Response) => {
     const layoutConfig = await registry.useGetLayoutConfig({req, res, settingsId: 'dl-main'});
 
     res.send(res.renderDatalensLayout(layoutConfig));

--- a/src/server/controllers/index.ts
+++ b/src/server/controllers/index.ts
@@ -1,6 +1,6 @@
-import {apiContollers} from './api';
+import {apiControllers} from './api';
 import {dlMainController} from './dl-main';
 import {navigateController} from './navigate';
 import {navigationController} from './navigation';
 
-export {apiContollers, dlMainController, navigationController, navigateController};
+export {apiControllers, dlMainController, navigateController, navigationController};

--- a/src/server/controllers/index.ts
+++ b/src/server/controllers/index.ts
@@ -1,6 +1,6 @@
-import api from './api';
-import dlMain from './dl-main';
-import navigate from './navigate';
-import navigation from './navigation';
+import {apiContollers} from './api';
+import {dlMainController} from './dl-main';
+import {navigateController} from './navigate';
+import {navigationController} from './navigation';
 
-export {api, dlMain, navigation, navigate};
+export {apiContollers, dlMainController, navigationController, navigateController};

--- a/src/server/controllers/navigate.ts
+++ b/src/server/controllers/navigate.ts
@@ -11,7 +11,7 @@ function navigateDefault(reqPath: string, res: Response) {
 }
 
 // eslint-disable-next-line complexity
-export default async (req: Request, res: Response) => {
+export const navigateController = async (req: Request, res: Response) => {
     const {url: reqUrl} = req;
 
     req.ctx.log('Navigate init', {reqUrl});

--- a/src/server/controllers/navigation.ts
+++ b/src/server/controllers/navigation.ts
@@ -7,7 +7,7 @@ import Utils from '../utils';
 import type {GatewayApiErrorResponse} from '../utils/gateway';
 
 /* eslint-disable consistent-return */
-export default async (req: Request, res: Response): Promise<void> => {
+export const navigationController = async (req: Request, res: Response): Promise<void> => {
     const {query, ctx} = req;
 
     const layoutConfig = await registry.useGetLayoutConfig({

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -1,4 +1,9 @@
-import {api, dlMain, navigate, navigation} from '../controllers';
+import {
+    apiContollers,
+    dlMainController,
+    navigateController,
+    navigationController,
+} from '../controllers';
 import {registry} from '../registry';
 import type {BasicControllers, ExtendedAppRouteDescription} from '../types/controllers';
 
@@ -9,22 +14,22 @@ export const getConfiguredRoute = (
     switch (controllerName) {
         case 'navigate':
             return {
-                handler: navigate,
+                handler: navigateController,
                 ...params,
             };
         case 'api.deleteLock':
             return {
-                handler: api.deleteLock,
+                handler: apiContollers.deleteLock,
                 ...params,
             };
         case 'dl-main':
             return {
-                handler: dlMain,
+                handler: dlMainController,
                 ...params,
             };
         case 'navigation':
             return {
-                handler: navigation,
+                handler: navigationController,
                 ...params,
             };
         case 'schematic-gateway': {

--- a/src/server/utils/routes.ts
+++ b/src/server/utils/routes.ts
@@ -1,5 +1,5 @@
 import {
-    apiContollers,
+    apiControllers,
     dlMainController,
     navigateController,
     navigationController,
@@ -19,7 +19,7 @@ export const getConfiguredRoute = (
             };
         case 'api.deleteLock':
             return {
-                handler: apiContollers.deleteLock,
+                handler: apiControllers.deleteLock,
                 ...params,
             };
         case 'dl-main':


### PR DESCRIPTION
In the self-telemetry logs, `unnamedController` appears. This is because the controller's name must either be explicitly set or taken as the name of the function. `const handlerNameLocal = handlerName || fn.name || UNNAMED_CONTROLLER` It is necessary to use named exports for controllers as this will provide a better understanding of the sources of errors.