### PR TITLE
Fix workbookSelectionMode in CollectionStructureDialog

### DIFF
--- a/src/ui/store/actions/collectionsStructure.ts
+++ b/src/ui/store/actions/collectionsStructure.ts
@@ -316,6 +316,7 @@ type GetStructureItemsAction =
 
 export const getStructureItems = ({
     collectionId,
+    includePermissionsInfo,
     page,
     filterString,
     orderField,
@@ -331,7 +332,7 @@ export const getStructureItems = ({
         return getSdk()
             .sdk.us.getStructureItems({
                 collectionId,
-                includePermissionsInfo: false,
+                includePermissionsInfo,
                 page,
                 filterString,
                 orderField,


### PR DESCRIPTION
In the future, need to separate collections selection and workbook selection in the dialog...
This logic becomes too confusing.