### PR TITLE
Fix template params validation settings

### DIFF
--- a/src/ui/components/DialogParameter/DefaultValueSection.tsx
+++ b/src/ui/components/DialogParameter/DefaultValueSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {DatePicker} from '@gravity-ui/date-components';
-import {dateTimeUtc} from '@gravity-ui/date-utils';
+import {dateTimeUtc, isValid} from '@gravity-ui/date-utils';
 import {RadioGroup, TextInput} from '@gravity-ui/uikit';
 import block from 'bem-cn-lite';
 import {I18n} from 'i18n';
@@ -42,7 +42,11 @@ export function DefaultValueSection({formState, updateFormState}: Props) {
     if (isDateField({data_type: formState.type})) {
         content = (
             <DatePicker
-                value={formState.defaultValue ? dateTimeUtc({input: formState.defaultValue}) : null}
+                value={
+                    isValid(formState.defaultValue)
+                        ? dateTimeUtc({input: formState.defaultValue})
+                        : null
+                }
                 format={getDatePickerFormat(formState.type, 'input')}
                 onUpdate={(dateTime) => {
                     let value = '';

--- a/src/ui/units/connections/components/ConnectorForm/components/RadioGroup/RadioGroup.scss
+++ b/src/ui/units/connections/components/ConnectorForm/components/RadioGroup/RadioGroup.scss
@@ -5,9 +5,20 @@
         color: var(--g-color-text-secondary);
     }
 
+    &__text-container {
+        display: flex;
+    }
+
+    &__text {
+        display: inline-flex;
+        align-items: center;
+        white-space: nowrap;
+    }
+
     &__icon {
         &_end {
-            margin-left: 5px;
+            margin-left: 4px;
+            display: inline-flex;
         }
 
         &_view_error {

--- a/src/ui/units/connections/components/ConnectorForm/components/RadioGroup/RadioGroup.tsx
+++ b/src/ui/units/connections/components/ConnectorForm/components/RadioGroup/RadioGroup.tsx
@@ -41,14 +41,16 @@ const RadioGroupOption = ({content, value}: RadioGroupItemOption) => {
             key={value}
             content={
                 <React.Fragment>
-                    <div>
-                        {text}
-                        {textEndIconData && (
-                            <Icon
-                                className={b('icon', {end: true, view: textEndIcon?.view})}
-                                data={textEndIconData}
-                            />
-                        )}
+                    <div className={b('text-container')}>
+                        <span className={b('text')}>
+                            {text}
+                            {textEndIconData && (
+                                <Icon
+                                    className={b('icon', {end: true, view: textEndIcon?.view})}
+                                    data={textEndIconData}
+                                />
+                            )}
+                        </span>
                     </div>
                     {hintText && (
                         <div className={b('hint')}>


### PR DESCRIPTION
1. Allow validation settings only for `string` parameters
2. Fix incorrect `date` & `datetime` values display
3. Fix RadioGroup option content end icon styles