### PR TITLE
AllPage and LandingPage paublic gallery fixes

### DIFF
--- a/src/shared/types/public-gallery.ts
+++ b/src/shared/types/public-gallery.ts
@@ -26,7 +26,7 @@ export type GalleryItem = {
 
 export type GalleryItemShort = Pick<
     GalleryItem,
-    'createdBy' | 'id' | 'images' | 'labels' | 'title'
+    'createdAt' | 'createdBy' | 'id' | 'images' | 'labels' | 'title'
 >;
 
 export type GalleryItemList = GalleryItemShort[];

--- a/src/ui/units/gallery/components/blocks/WorkOfMonth/WorkOfMonth.tsx
+++ b/src/ui/units/gallery/components/blocks/WorkOfMonth/WorkOfMonth.tsx
@@ -66,8 +66,8 @@ export const WorkOfMonth = ({id}: {id: string}) => {
                     <div className={b('title', {media: activeMediaQuery})}>{title}</div>
                     {!isActiveMediaQueryS && <div className={b('description')}>{description}</div>}
                     {!isActiveMediaQueryS && (
-                        <div className={b('actions')} onClick={handleOpen}>
-                            <Button size="l" view="action">
+                        <div className={b('actions')}>
+                            <Button size="l" view="action" onClick={handleOpen}>
                                 {i18n('button_open')}
                             </Button>
                             <Button size="l" view="flat" onClick={handleClick}>

--- a/src/ui/units/gallery/components/pages/AllPage/AllPage.tsx
+++ b/src/ui/units/gallery/components/pages/AllPage/AllPage.tsx
@@ -11,6 +11,7 @@ import {
     useLayoutContext,
     useThemeType,
 } from '@gravity-ui/uikit';
+import type {SelectOption} from '@gravity-ui/uikit';
 import {unstable_Breadcrumbs as Breadcrumbs} from '@gravity-ui/uikit/unstable';
 import {useHistory, useLocation} from 'react-router-dom';
 import {GALLERY_ITEM_CATEGORY} from 'shared/constants';
@@ -51,6 +52,25 @@ interface UseGalleryItemsProps {
     search: string;
     category: string;
     lang: string;
+}
+
+function useSortedGalleryItems({items}: {items: GalleryItemShort[]}) {
+    const sortedItems = React.useMemo(() => {
+        return [...items].sort((item1, item2) => {
+            if (item1.createdAt === undefined && item2.createdAt === undefined) {
+                return 0;
+            }
+            if (item1.createdAt === undefined) {
+                return 1;
+            }
+            if (item2.createdAt === undefined) {
+                return -1;
+            }
+            return item2.createdAt - item1.createdAt;
+        });
+    }, [items]);
+
+    return {sortedItems};
 }
 
 function useFilteredGalleryItems({
@@ -121,6 +141,19 @@ export function AllPage() {
     const history = useHistory();
     const {search: searchParams} = useLocation();
     const {isLoading, data: items = []} = useGetGalleryItemsQuery();
+    const themeType = useThemeType();
+    const {isLoading: isMetaLoading, data: metaData} = useGetGalleryMetaQuery();
+    const [search, setSearch] = React.useState('');
+    const [category, setCategory] = React.useState<string>(SPECIAL_CATEGORY.ALL);
+    const lang = getLang();
+    const {sortedItems} = useSortedGalleryItems({items});
+    const {filteredItems} = useFilteredGalleryItems({
+        category,
+        items: sortedItems,
+        search,
+        lang,
+        editorChoiceIds: metaData?.editorChoice.ids ?? [],
+    });
     const availableCategories = React.useMemo(() => {
         return Array.from(
             new Set(
@@ -128,8 +161,35 @@ export function AllPage() {
             ),
         );
     }, [items]);
-    const [search, setSearch] = React.useState('');
-    const [category, setCategory] = React.useState<string>(SPECIAL_CATEGORY.ALL);
+    const selectOptions: SelectOption[] = React.useMemo(() => {
+        const allOptions = Array.from(
+            new Set([...CATEGORIES_SELECT_VALUES, ...availableCategories]),
+        );
+        const sortedOptions = allOptions
+            .filter((option) => option !== SPECIAL_CATEGORY.ALL)
+            .sort((option1, option2) => {
+                const content1 = getCategorySelectOptionContent(option1);
+                const content2 = getCategorySelectOptionContent(option2);
+                return content1.localeCompare(content2);
+            })
+            .map((value) => ({
+                value,
+                content: getCategorySelectOptionContent(value),
+            }));
+
+        return [
+            {
+                value: SPECIAL_CATEGORY.ALL,
+                content: getCategorySelectOptionContent(SPECIAL_CATEGORY.ALL),
+            },
+            ...sortedOptions,
+        ];
+    }, [availableCategories]);
+
+    const isPromo = DL.IS_NOT_AUTHENTICATED;
+    const baseMods: CnMods = {media: activeMediaQuery, maxWidth: isPromo};
+
+    const {pageOffset, actionPanelRef} = useActionPanelLayout();
 
     React.useEffect(() => {
         if (!isLoading && items.length > 0) {
@@ -149,26 +209,6 @@ export function AllPage() {
             }
         }
     }, [availableCategories, isLoading, items.length, searchParams]);
-
-    const isPromo = DL.IS_NOT_AUTHENTICATED;
-    const baseMods: CnMods = {media: activeMediaQuery, maxWidth: isPromo};
-
-    const lang = getLang();
-    const themeType = useThemeType();
-
-    const {isLoading: isMetaLoading, data: metaData} = useGetGalleryMetaQuery();
-    const {filteredItems} = useFilteredGalleryItems({
-        category,
-        items,
-        search,
-        lang,
-        editorChoiceIds: metaData?.editorChoice.ids ?? [],
-    });
-    const selectOptions = Array.from(
-        new Set([...CATEGORIES_SELECT_VALUES, ...availableCategories]),
-    );
-
-    const {pageOffset, actionPanelRef} = useActionPanelLayout();
 
     if (isLoading || isMetaLoading) {
         return (
@@ -214,6 +254,7 @@ export function AllPage() {
                     </Col>
                     <Col m="4" s="12">
                         <Select
+                            filterable={true}
                             onUpdate={(value) => setCategory(value[0])}
                             placeholder={i18n('filter_category_placeholder')}
                             size="l"
@@ -222,8 +263,8 @@ export function AllPage() {
                         >
                             {selectOptions.map((value) => {
                                 return (
-                                    <Select.Option key={value} value={value}>
-                                        {getCategorySelectOptionContent(value)}
+                                    <Select.Option key={value.value} value={value.value}>
+                                        {value.content}
                                     </Select.Option>
                                 );
                             })}

--- a/src/ui/units/gallery/components/pages/LandingPage/LandingPage.tsx
+++ b/src/ui/units/gallery/components/pages/LandingPage/LandingPage.tsx
@@ -148,7 +148,9 @@ function PromoBlockRow({galleryItems, activeMediaQuery, editorChoiceIds}: PromoB
     const themeType = useThemeType();
     const itemsByLabels = groupGalleryItemsByLabels(galleryItems);
     const primaryItems = galleryItems.filter((item) => editorChoiceIds?.includes(item.id));
-    const primaryImagesProps: AsyncImageProps[] = primaryItems
+    const primaryImagesProps: AsyncImageProps[] = sortBy(primaryItems, (item) =>
+        editorChoiceIds?.indexOf(item.id),
+    )
         .slice(0, 3)
         .map((item, index, list) => {
             const opacity = activeMediaQuery === 's' ? 1 : 1 - (list.length - 1 - index) * 0.1;


### PR DESCRIPTION
In `src/shared/types/public-gallery.ts`:
- Added `createdAt` field to the `GalleryItemShort` type

In `src/ui/units/gallery/components/blocks/WorkOfMonth/WorkOfMonth.tsx`:
- Fixed click handler for the "Open" button - moved from div to the button itself

In `src/ui/units/gallery/components/pages/AllPage/AllPage.tsx`:
- Added new `useSortedGalleryItems` hook for sorting gallery items by creation date
- Enhanced category handling in the select component:
  - Added filtering capability `(filterable={true})`
  - Improved category sorting
- Reorganized code for better readability
- Added sorting of items by creation date

In `src/ui/units/gallery/components/pages/LandingPage/LandingPage.tsx`:
- Added sorting of primary items (primaryItems) by their order in `editorChoiceIds`