### PR TITLE
Update ChangePasswordDialog to conditionally set oldPassword based on…

### DIFF
--- a/src/ui/units/auth/components/ChangePasswordDialog/ChangePasswordDialog.tsx
+++ b/src/ui/units/auth/components/ChangePasswordDialog/ChangePasswordDialog.tsx
@@ -146,7 +146,8 @@ export function ChangePasswordDialog({
                 data: {
                     userId,
                     newPassword,
-                    oldPassword: isOwnProfile ? oldPassword : undefined,
+                    oldPassword:
+                        isOwnProfile && oldPassword !== 'admin' ? oldPassword : undefined,
                 },
                 onSuccess: handleSuccessUpdate,
                 onError: handleErrorUpdate,


### PR DESCRIPTION
I was rocking around with self-hosted datalens instance and encountered a problem with reseting the default password.
As the default password is admin -> it doesn't pass through the validation schema. So I decided to look for the place to fix this.

As it appears like in backend you are using some OAuth provide, this might be the place to do this fix. I am not a professional at .tsx so at least I help you find a little bug (some might say it is not, however I wish such tools to be more accesible for humanity and so that unexpirienced users can change their password in UI and not in docker)

I hereby agree to the terms of the CLA available at:  https://yandex.ru/legal/cla/?lang=en.

