### PR TITLE
Add autofocus to a RenameEntryDialog's input

### DIFF
--- a/src/ui/units/workbooks/components/RenameEntryDialog/RenameEntryDialog.tsx
+++ b/src/ui/units/workbooks/components/RenameEntryDialog/RenameEntryDialog.tsx
@@ -35,6 +35,7 @@ const RenameEntryDialog = React.memo<Props>(({open, data, onClose}) => {
     const isLoading = useSelector(selectRenameEntryIsLoading);
 
     const [newNameValue, setNewNameValue] = React.useState(data.name);
+    const textInputControlRef = React.useRef<HTMLInputElement>(null);
 
     const handleApply = React.useCallback(() => {
         dispatch(
@@ -55,11 +56,21 @@ const RenameEntryDialog = React.memo<Props>(({open, data, onClose}) => {
     }, [data.name, newNameValue]);
 
     return (
-        <Dialog size="s" open={open} onClose={onClose} onEnterKeyDown={handleApply}>
+        <Dialog
+            size="s"
+            open={open}
+            onClose={onClose}
+            onEnterKeyDown={handleApply}
+            initialFocus={textInputControlRef}
+        >
             <Dialog.Header caption={i18n('label_rename-entry')} />
             <Dialog.Body>
                 <div className={b('label')}>{i18n('label_title')}</div>
-                <TextInput value={newNameValue} onUpdate={setNewNameValue} />
+                <TextInput
+                    value={newNameValue}
+                    controlRef={textInputControlRef}
+                    onUpdate={setNewNameValue}
+                />
             </Dialog.Body>
             <Dialog.Footer
                 onClickButtonCancel={onClose}


### PR DESCRIPTION
input's autoFocus is not working when an input is placed inside Modal or Dialog components. Possible problem is that a modal's animation starts from 'display: none' while the inner content has already been rendered.

I wrote a sandbox with a small research of possible solutions : https://codesandbox.io/p/sandbox/quizzical-chatelet-gzy3vr

Somehow i found a Modal's `initialFocus` prop and decided to use it here (the last solution in the sandbox). Unfortunately, use cases of this prop are not described in docs, but looks like that the prop was created exactly to fix issues like the one described in the ticket.

InitialFocus can receive a Ref of an element (or an index number of interactive element inside a modal body) which need to be focused when a modal opens.