### PR TITLE
Move serverFeatureWithBoundedContext to global beforeAuthMiddleware

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -35,6 +35,8 @@ if (nodekit.config.isAuthEnabled) {
 nodekit.config.appAllowedLangs = nodekit.config.regionalEnvConfig?.allowLanguages;
 nodekit.config.appDefaultLang = nodekit.config.regionalEnvConfig?.defaultLang;
 
+nodekit.config.appBeforeAuthMiddleware = [serverFeatureWithBoundedContext];
+
 const app = initOpensourceApp(nodekit);
 registry.setupApp(app);
 

--- a/src/server/modes/opensource/app.ts
+++ b/src/server/modes/opensource/app.ts
@@ -17,7 +17,6 @@ import {
     createAppLayoutMiddleware,
     getCtxMiddleware,
     patchLogger,
-    serverFeatureWithBoundedContext,
     xDlContext,
 } from '../../middlewares';
 import {registry} from '../../registry';
@@ -72,7 +71,6 @@ function initDataLensApp({
     afterAuth: AppMiddleware[];
 }) {
     beforeAuth.push(
-        serverFeatureWithBoundedContext,
         createAppLayoutMiddleware({
             plugins: [createLayoutPlugin(), createUikitPlugin()],
             getAppLayoutSettings,
@@ -124,7 +122,7 @@ function initChartsApp({
     afterAuth.push(setSubrequestHeaders, patchLogger);
 
     if (isChartsMode) {
-        beforeAuth.push(serverFeatureWithBoundedContext, beforeAuthDefaults);
+        beforeAuth.push(beforeAuthDefaults);
         afterAuth.push(getCtxMiddleware());
     }
 
@@ -144,6 +142,6 @@ function initApiApp({
     // As charts app execpt chartEngine
     if (isApiMode) {
         afterAuth.push(xDlContext(), setSubrequestHeaders, patchLogger, getCtxMiddleware());
-        beforeAuth.push(serverFeatureWithBoundedContext, beforeAuthDefaults);
+        beforeAuth.push(beforeAuthDefaults);
     }
 }


### PR DESCRIPTION
- Move serverFeatureWithBoundedContext from individual app configs to global appBeforeAuthMiddleware
- Remove duplicate middleware registrations from DataLens, Charts, and API app initialization

